### PR TITLE
Bootstrap core toolkit modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ src/jobofcron.egg-info/
 __pycache__/
 src/jobofcron/__pycache__/
 *.pyc
+jobofcron_data.json
+generated_documents/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts
+src/jobofcron.egg-info/
+__pycache__/
+src/jobofcron/__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Jobofcron is a roadmap for an automated job application assistant that tailors e
 - **User profile manager** – stores personal information, work history, skills, certifications, felony-friendly notes, and preferred industries. This evolves over time by asking the user for missing details.
 - **Job discovery engine** – searches Google for job + location queries, prioritising results that land on company career sites so we can apply directly and avoid aggregator anti-bot hurdles.
 - **Evaluation & matching** – compares job descriptions with the stored talent/skills inventory to determine fit and to decide whether to request more info from the user.
-- **Resume & cover letter generator** – adapts resume sections and cover letters using the known profile plus any job-specific prompts from the user.
-- **Application scheduler** – queues applications, spaces them out with configurable breaks, and tracks submission history to avoid rate limits.
+- **Resume & cover letter generator** – adapts resume sections and cover letters using the known profile plus any job-specific prompts from the user and saves reusable drafts for each opportunity.
+- **Application scheduler & queue** – queues applications, spaces them out with configurable breaks, persists the backlog, and tracks submission history to avoid rate limits.
+- **Browser automation** – drives Playwright to fill in company career portals directly, supporting dry runs when you simply want to generate documents.
 - **Audit trail** – keeps a running ledger of applied jobs, outcomes, and newly discovered skills for future iterations.
 
 ## Workflow at a Glance
@@ -25,10 +26,14 @@ Initial scaffolding for the automation toolkit now lives under ``src/jobofcron``
 - ``profile.py`` – data models for the evolving user profile and job preferences.
 - ``skills_inventory.py`` – tracks skills encountered in job descriptions and the resulting outcomes.
 - ``scheduler.py`` – spaces applications over time with configurable breaks.
-- ``storage.py`` – persists profiles and skill snapshots to JSON for iterative learning.
-- ``cli.py`` – a small command line utility for updating preferences, adding skills, planning application pacing, and sourcing direct-apply leads from Google.
+- ``storage.py`` – persists profiles, skill snapshots, and the queued application backlog to JSON for iterative learning.
+- ``cli.py`` – a command line utility for updating preferences, adding skills, planning application pacing, generating tailored documents, queueing applications, and sourcing direct-apply leads from Google.
 - ``job_search.py`` – SerpAPI-backed helpers that query Google, flag aggregator domains, and filter for company-owned listings.
 - ``job_matching.py`` – heuristics that analyse job descriptions, surface questions for the candidate, and suggest resume updates.
+- ``document_generation.py`` – renders quick-turn resume and cover-letter drafts tailored to a posting and the stored profile.
+- ``application_queue.py`` – manages the persisted queue of scheduled applications and their statuses.
+- ``application_automation.py`` – wraps Playwright for direct company-site submissions.
+- ``worker.py`` – background runner that refreshes documents and processes the queue over time.
 
 ### Running the CLI
 
@@ -39,6 +44,9 @@ python -m jobofcron.cli prefs --min-salary 85000 --locations "Remote" "Austin, T
 python -m jobofcron.cli add-skill "Customer Success"
 python -m jobofcron.cli plan --titles "Success Manager" "Support Lead" --companies "Acme" "Globex"
 python -m jobofcron.cli analyze --title "Customer Success Manager" --company "Acme" --location "Remote" --salary '$70,000 - $90,000' --description-file posting.txt
+python -m jobofcron.cli generate-docs --title "Customer Success Manager" --company "Acme" --location "Remote" --salary '$70,000 - $90,000' --description-file posting.txt --output-dir generated_documents --enqueue --apply-at 2024-05-01T09:30 --apply-url https://careers.example.com/apply
+python -m jobofcron.cli apply --queue-id "Customer Success Manager@Acme" --dry-run
+python -m jobofcron.cli worker --loop --interval 600 --documents-dir generated_documents
 python -m jobofcron.cli search --title "Customer Success Manager" --location "Austin, TX" --limit 5 --direct-only --sample-response samples/serpapi_demo_response.json --verbose
 ```
 
@@ -60,9 +68,22 @@ saved response via ``--sample-response`` for offline experimentation. Results ar
 tagged as ``DIRECT`` when the detected domain is not a known aggregator, helping
 you focus on company-owned application flows.
 
+### Automation Extras
+
+To drive direct applications you will need the optional automation dependencies:
+
+```bash
+pip install --editable .[automation]
+playwright install
+```
+
+Use ``--dry-run`` with the ``apply`` and ``worker`` commands to generate
+documents without launching a browser session. Failed attempts are automatically
+rescheduled based on the configured retry delay.
+
 ## Next Steps
-- Integrate automated form filling for company career portals (Greenhouse, Lever, Workday, etc.).
-- Extend document generation to tailor resumes and cover letters automatically.
-- Build an event loop/service that executes the planned schedule and records outcomes.
+- Add Craigslist and other regional job board search integrations to broaden sourcing.
+- Expand Playwright recipes for common applicant tracking systems (Greenhouse, Lever, Workday, iCIMS).
+- Capture post-submission outcomes (interviews, offers) to feed back into the skills inventory and scheduling heuristics.
 
 These building blocks provide the "pieces" you can follow as we iterate toward the working product.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Initial scaffolding for the automation toolkit now lives under ``src/jobofcron``
 - ``scheduler.py`` – spaces applications over time with configurable breaks.
 - ``storage.py`` – persists profiles and skill snapshots to JSON for iterative learning.
 - ``cli.py`` – a small command line utility for updating preferences, adding skills, and planning application pacing.
+- ``job_matching.py`` – heuristics that analyse job descriptions, surface questions for the candidate, and suggest resume updates.
 
 ### Running the CLI
 
@@ -36,11 +37,19 @@ python -m jobofcron.cli show
 python -m jobofcron.cli prefs --min-salary 85000 --locations "Remote" "Austin, TX"
 python -m jobofcron.cli add-skill "Customer Success"
 python -m jobofcron.cli plan --titles "Success Manager" "Support Lead" --companies "Acme" "Globex"
+python -m jobofcron.cli analyze --title "Customer Success Manager" --company "Acme" --location "Remote" --salary '$70,000 - $90,000' --description-file posting.txt
 ```
 
 If you prefer not to install the package, prefix commands with
 ``PYTHONPATH=src``. The CLI stores data in ``jobofcron_data.json`` by default.
 You can point to an alternate location with ``--storage``.
+
+The ``analyze`` command will ingest either ``--description`` text or
+``--description-file`` contents, score the match, suggest clarifying questions,
+and log the skills it discovered so future applications know they are in
+regular demand. When providing shell arguments that contain ``$`` (such as
+salary ranges), wrap them in single quotes so the shell does not treat them as
+environment variable lookups.
 
 ## Next Steps
 - Hook up real Indeed search/scrape integration.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ saved response via ``--sample-response`` for offline experimentation. Results ar
 tagged as ``DIRECT`` when the detected domain is not a known aggregator, helping
 you focus on company-owned application flows.
 
+### Streamlit control centre
+
+Prefer a point-and-click experience? Install the optional UI extras and launch
+the Streamlit dashboard:
+
+```bash
+pip install --editable .[ui]
+streamlit run src/jobofcron/streamlit_app.py
+```
+
+The app offers:
+
+- **Profile editor** – update contact details, salary expectations, and location
+  preferences without touching JSON files.
+- **Job search** – run SerpAPI-backed Google searches (or upload saved JSON
+  responses) and focus on company-owned application flows.
+- **Job analysis** – paste descriptions, view visual match scores, capture
+  follow-up questions, and queue promising postings for automation.
+- **Skills dashboard** – review in-demand skills, add notes, and log interviews
+  or offers to guide future tailoring.
+- **Application queue planner** – inspect pending submissions, reschedule,
+  record successes, and export search results to CSV for offline sharing.
+
 ### Automation Extras
 
 To drive direct applications you will need the optional automation dependencies:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # Jobofcron
-test auto job application
+
+Jobofcron is a roadmap for an automated Indeed job application assistant that tailors each submission to the candidate's background, salary expectations, and location preferences while pacing applications to avoid spammy behaviour.
+
+## System Overview
+- **User profile manager** – stores personal information, work history, skills, certifications, felony-friendly notes, and preferred industries. This evolves over time by asking the user for missing details.
+- **Job discovery engine** – searches Indeed for remote or location-specific roles that meet salary and felon-friendly filters while focusing on selected domains.
+- **Evaluation & matching** – compares job descriptions with the stored talent/skills inventory to determine fit and to decide whether to request more info from the user.
+- **Resume & cover letter generator** – adapts resume sections and cover letters using the known profile plus any job-specific prompts from the user.
+- **Application scheduler** – queues applications, spaces them out with configurable breaks, and tracks submission history to avoid rate limits.
+- **Audit trail** – keeps a running ledger of applied jobs, outcomes, and newly discovered skills for future iterations.
+
+## Workflow at a Glance
+1. Collect initial user profile (resume, experience, salary minimum, locations, felon-friendly requirements).
+2. Run job searches on Indeed filtered by the profile constraints.
+3. Score each posting using the evaluation engine; request clarifications from the user when required.
+4. Generate tailored resume/cover letter packages.
+5. Apply according to the scheduler, respecting cool-down periods.
+6. Update the audit trail and expand the skills/talent inventory.
+
+## Local Toolkit
+
+Initial scaffolding for the automation toolkit now lives under ``src/jobofcron``:
+
+- ``profile.py`` – data models for the evolving user profile and job preferences.
+- ``skills_inventory.py`` – tracks skills encountered in job descriptions and the resulting outcomes.
+- ``scheduler.py`` – spaces applications over time with configurable breaks.
+- ``storage.py`` – persists profiles and skill snapshots to JSON for iterative learning.
+- ``cli.py`` – a small command line utility for updating preferences, adding skills, and planning application pacing.
+
+### Running the CLI
+
+```bash
+pip install --editable .
+python -m jobofcron.cli show
+python -m jobofcron.cli prefs --min-salary 85000 --locations "Remote" "Austin, TX"
+python -m jobofcron.cli add-skill "Customer Success"
+python -m jobofcron.cli plan --titles "Success Manager" "Support Lead" --companies "Acme" "Globex"
+```
+
+If you prefer not to install the package, prefix commands with
+``PYTHONPATH=src``. The CLI stores data in ``jobofcron_data.json`` by default.
+You can point to an alternate location with ``--storage``.
+
+## Next Steps
+- Hook up real Indeed search/scrape integration.
+- Extend document generation to tailor resumes and cover letters automatically.
+- Build an event loop/service that executes the planned schedule and records outcomes.
+
+These building blocks provide the "pieces" you can follow as we iterate toward the working product.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 automation = [
     "playwright>=1.44",
 ]
+ui = [
+    "streamlit>=1.32",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jobofcron"
 version = "0.1.0"
-description = "Toolkit for automating Indeed job applications"
+description = "Toolkit for automating job applications"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{name = "Jobofcron"}]
+dependencies = [
+    "requests>=2.31",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,10 @@ dependencies = [
     "requests>=2.31",
 ]
 
+[project.optional-dependencies]
+automation = [
+    "playwright>=1.44",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jobofcron"
+version = "0.1.0"
+description = "Toolkit for automating Indeed job applications"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Jobofcron"}]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ automation = [
 ui = [
     "streamlit>=1.32",
 ]
+ai = [
+    "openai>=1.14",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/samples/serpapi_demo_response.json
+++ b/samples/serpapi_demo_response.json
@@ -1,0 +1,28 @@
+{
+  "organic_results": [
+    {
+      "title": "Customer Success Manager - Acme Corp Careers",
+      "link": "https://careers.acme.com/jobs/customer-success-manager",
+      "snippet": "Lead onboarding and retention programs for Acme's enterprise customers.",
+      "position": 1
+    },
+    {
+      "title": "Customer Success Manager - Globex",
+      "link": "https://jobs.globex.com/customer-success-manager",
+      "snippet": "Partner with product and support teams to drive adoption.",
+      "position": 2
+    },
+    {
+      "title": "Customer Success Manager Job in Austin, TX - Indeed",
+      "link": "https://www.indeed.com/viewjob?jk=123456",
+      "snippet": "Apply on Indeed for the latest customer success openings.",
+      "position": 3
+    },
+    {
+      "title": "Customer Success Manager - Remote - Example Company",
+      "link": "https://example.com/careers/customer-success-manager",
+      "snippet": "Remote-first SaaS company seeking experienced CSMs.",
+      "position": 4
+    }
+  ]
+}

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -1,11 +1,13 @@
 """Jobofcron – Indeed job application automation toolkit."""
 
-from .application_automation import AutomationDependencyError, DirectApplyAutomation
+from .application_automation import AutomationDependencyError, DirectApplyAutomation, EmailApplicationSender
 from .application_queue import ApplicationQueue, QueuedApplication
 from .document_generation import (
     AIDocumentGenerator,
     DocumentGenerationDependencyError,
     DocumentGenerationError,
+    available_cover_letter_templates,
+    available_resume_templates,
     generate_cover_letter,
     generate_resume,
 )
@@ -37,10 +39,13 @@ __all__ = [
     "QueuedApplication",
     "generate_resume",
     "generate_cover_letter",
+    "available_resume_templates",
+    "available_cover_letter_templates",
     "AIDocumentGenerator",
     "DocumentGenerationDependencyError",
     "DocumentGenerationError",
     "DirectApplyAutomation",
+    "EmailApplicationSender",
     "AutomationDependencyError",
     "JobAutomationWorker",
 ]

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -1,6 +1,7 @@
 """Jobofcron – Indeed job application automation toolkit."""
 
 from .job_matching import JobPosting, MatchAssessment, analyse_job_fit, extract_required_skills
+from .job_search import GoogleJobSearch, SearchResult
 from .profile import CandidateProfile, Experience, JobPreference
 from .scheduler import ScheduledApplication, plan_schedule
 from .skills_inventory import SkillRecord, SkillsInventory
@@ -11,6 +12,8 @@ __all__ = [
     "MatchAssessment",
     "analyse_job_fit",
     "extract_required_skills",
+    "GoogleJobSearch",
+    "SearchResult",
     "CandidateProfile",
     "Experience",
     "JobPreference",

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -2,9 +2,15 @@
 
 from .application_automation import AutomationDependencyError, DirectApplyAutomation
 from .application_queue import ApplicationQueue, QueuedApplication
-from .document_generation import generate_cover_letter, generate_resume
+from .document_generation import (
+    AIDocumentGenerator,
+    DocumentGenerationDependencyError,
+    DocumentGenerationError,
+    generate_cover_letter,
+    generate_resume,
+)
 from .job_matching import JobPosting, MatchAssessment, analyse_job_fit, extract_required_skills
-from .job_search import GoogleJobSearch, SearchResult
+from .job_search import CraigslistSearch, GoogleJobSearch, SearchResult
 from .profile import CandidateProfile, Experience, JobPreference
 from .scheduler import ScheduledApplication, plan_schedule
 from .skills_inventory import SkillRecord, SkillsInventory
@@ -17,6 +23,7 @@ __all__ = [
     "analyse_job_fit",
     "extract_required_skills",
     "GoogleJobSearch",
+    "CraigslistSearch",
     "SearchResult",
     "CandidateProfile",
     "Experience",
@@ -30,6 +37,9 @@ __all__ = [
     "QueuedApplication",
     "generate_resume",
     "generate_cover_letter",
+    "AIDocumentGenerator",
+    "DocumentGenerationDependencyError",
+    "DocumentGenerationError",
     "DirectApplyAutomation",
     "AutomationDependencyError",
     "JobAutomationWorker",

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -1,11 +1,15 @@
 """Jobofcron – Indeed job application automation toolkit."""
 
+from .application_automation import AutomationDependencyError, DirectApplyAutomation
+from .application_queue import ApplicationQueue, QueuedApplication
+from .document_generation import generate_cover_letter, generate_resume
 from .job_matching import JobPosting, MatchAssessment, analyse_job_fit, extract_required_skills
 from .job_search import GoogleJobSearch, SearchResult
 from .profile import CandidateProfile, Experience, JobPreference
 from .scheduler import ScheduledApplication, plan_schedule
 from .skills_inventory import SkillRecord, SkillsInventory
 from .storage import Storage
+from .worker import JobAutomationWorker
 
 __all__ = [
     "JobPosting",
@@ -22,4 +26,11 @@ __all__ = [
     "ScheduledApplication",
     "Storage",
     "plan_schedule",
+    "ApplicationQueue",
+    "QueuedApplication",
+    "generate_resume",
+    "generate_cover_letter",
+    "DirectApplyAutomation",
+    "AutomationDependencyError",
+    "JobAutomationWorker",
 ]

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -1,11 +1,16 @@
 """Jobofcron – Indeed job application automation toolkit."""
 
+from .job_matching import JobPosting, MatchAssessment, analyse_job_fit, extract_required_skills
 from .profile import CandidateProfile, Experience, JobPreference
-from .skills_inventory import SkillRecord, SkillsInventory
 from .scheduler import ScheduledApplication, plan_schedule
+from .skills_inventory import SkillRecord, SkillsInventory
 from .storage import Storage
 
 __all__ = [
+    "JobPosting",
+    "MatchAssessment",
+    "analyse_job_fit",
+    "extract_required_skills",
     "CandidateProfile",
     "Experience",
     "JobPreference",

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -1,0 +1,17 @@
+"""Jobofcron – Indeed job application automation toolkit."""
+
+from .profile import CandidateProfile, Experience, JobPreference
+from .skills_inventory import SkillRecord, SkillsInventory
+from .scheduler import ScheduledApplication, plan_schedule
+from .storage import Storage
+
+__all__ = [
+    "CandidateProfile",
+    "Experience",
+    "JobPreference",
+    "SkillRecord",
+    "SkillsInventory",
+    "ScheduledApplication",
+    "Storage",
+    "plan_schedule",
+]

--- a/src/jobofcron/__init__.py
+++ b/src/jobofcron/__init__.py
@@ -11,6 +11,7 @@ from .document_generation import (
     generate_cover_letter,
     generate_resume,
 )
+from .job_history import AppliedJobRegistry
 from .job_matching import JobPosting, MatchAssessment, analyse_job_fit, extract_required_skills
 from .job_search import CraigslistSearch, GoogleJobSearch, SearchResult
 from .profile import CandidateProfile, Experience, JobPreference
@@ -27,6 +28,7 @@ __all__ = [
     "GoogleJobSearch",
     "CraigslistSearch",
     "SearchResult",
+    "AppliedJobRegistry",
     "CandidateProfile",
     "Experience",
     "JobPreference",

--- a/src/jobofcron/application_queue.py
+++ b/src/jobofcron/application_queue.py
@@ -1,0 +1,141 @@
+"""Utilities for managing queued job applications."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from .job_matching import JobPosting
+
+
+@dataclass
+class QueuedApplication:
+    """Metadata for an application to execute at a future time."""
+
+    posting: JobPosting
+    apply_at: datetime
+    status: str = "pending"
+    resume_path: Optional[str] = None
+    cover_letter_path: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+    attempts: int = 0
+    last_error: Optional[str] = None
+
+    @property
+    def job_id(self) -> str:
+        if self.posting.id:
+            return str(self.posting.id)
+        return f"{self.posting.title}@{self.posting.company}"
+
+    def mark_success(self) -> None:
+        self.status = "applied"
+        self.attempts += 1
+        self.last_error = None
+        self.notes.append(f"Applied successfully on {datetime.now().isoformat(timespec='seconds')}")
+
+    def mark_failure(self, error: str) -> None:
+        self.status = "pending"
+        self.attempts += 1
+        self.last_error = error
+        self.notes.append(f"Attempt failed on {datetime.now().isoformat(timespec='seconds')}: {error}")
+
+    def defer(self, new_time: datetime) -> None:
+        self.apply_at = new_time
+
+    def to_dict(self) -> dict:
+        return {
+            "posting": {
+                "id": self.posting.id,
+                "title": self.posting.title,
+                "company": self.posting.company,
+                "location": self.posting.location,
+                "salary_text": self.posting.salary_text,
+                "description": self.posting.description,
+                "tags": list(self.posting.tags),
+                "felon_friendly": self.posting.felon_friendly,
+                "apply_url": self.posting.apply_url,
+            },
+            "apply_at": self.apply_at.isoformat(),
+            "status": self.status,
+            "resume_path": self.resume_path,
+            "cover_letter_path": self.cover_letter_path,
+            "notes": list(self.notes),
+            "attempts": self.attempts,
+            "last_error": self.last_error,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "QueuedApplication":
+        posting_data = payload.get("posting", {})
+        posting = JobPosting(
+            id=posting_data.get("id"),
+            title=posting_data.get("title", ""),
+            company=posting_data.get("company", ""),
+            location=posting_data.get("location"),
+            salary_text=posting_data.get("salary_text"),
+            description=posting_data.get("description", ""),
+            tags=list(posting_data.get("tags", [])),
+            felon_friendly=posting_data.get("felon_friendly"),
+            apply_url=posting_data.get("apply_url"),
+        )
+        apply_at = datetime.fromisoformat(payload["apply_at"])
+        return cls(
+            posting=posting,
+            apply_at=apply_at,
+            status=payload.get("status", "pending"),
+            resume_path=payload.get("resume_path"),
+            cover_letter_path=payload.get("cover_letter_path"),
+            notes=list(payload.get("notes", [])),
+            attempts=payload.get("attempts", 0),
+            last_error=payload.get("last_error"),
+        )
+
+
+@dataclass
+class ApplicationQueue:
+    """Collection helper with convenience methods for queue operations."""
+
+    items: List[QueuedApplication] = field(default_factory=list)
+
+    def add(self, application: QueuedApplication) -> None:
+        existing = self.get(application.job_id)
+        if existing:
+            # Replace existing entry while preserving accumulated notes.
+            application.notes = existing.notes + application.notes
+            application.attempts = existing.attempts
+            application.last_error = existing.last_error
+            self.items = [app for app in self.items if app.job_id != application.job_id]
+        self.items.append(application)
+
+    def get(self, job_id: str) -> Optional[QueuedApplication]:
+        for application in self.items:
+            if application.job_id == job_id:
+                return application
+        return None
+
+    def due(self, when: datetime) -> List[QueuedApplication]:
+        pending = [app for app in self.items if app.status == "pending" and app.apply_at <= when]
+        return sorted(pending, key=lambda app: app.apply_at)
+
+    def pending(self) -> List[QueuedApplication]:
+        return [app for app in self.items if app.status == "pending"]
+
+    def to_snapshot(self) -> List[dict]:
+        return [app.to_dict() for app in self.items]
+
+    @classmethod
+    def from_snapshot(cls, payload: Iterable[dict]) -> "ApplicationQueue":
+        items = []
+        for entry in payload or []:
+            try:
+                items.append(QueuedApplication.from_dict(entry))
+            except Exception as exc:  # pragma: no cover - defensive programming
+                # Skip malformed entries but capture context.
+                broken = QueuedApplication(
+                    posting=JobPosting(title="Unknown", company="Unknown"),
+                    apply_at=datetime.now(),
+                    status="failed",
+                    notes=[f"Could not load entry: {exc}"],
+                )
+                items.append(broken)
+        return cls(items=items)

--- a/src/jobofcron/application_queue.py
+++ b/src/jobofcron/application_queue.py
@@ -17,6 +17,10 @@ class QueuedApplication:
     status: str = "pending"
     resume_path: Optional[str] = None
     cover_letter_path: Optional[str] = None
+    resume_template: str = "traditional"
+    cover_letter_template: str = "traditional"
+    custom_resume_template: Optional[str] = None
+    custom_cover_letter_template: Optional[str] = None
     notes: List[str] = field(default_factory=list)
     attempts: int = 0
     last_error: Optional[str] = None
@@ -69,11 +73,16 @@ class QueuedApplication:
                 "tags": list(self.posting.tags),
                 "felon_friendly": self.posting.felon_friendly,
                 "apply_url": self.posting.apply_url,
+                "contact_email": self.posting.contact_email,
             },
             "apply_at": self.apply_at.isoformat(),
             "status": self.status,
             "resume_path": self.resume_path,
             "cover_letter_path": self.cover_letter_path,
+            "resume_template": self.resume_template,
+            "cover_letter_template": self.cover_letter_template,
+            "custom_resume_template": self.custom_resume_template,
+            "custom_cover_letter_template": self.custom_cover_letter_template,
             "notes": list(self.notes),
             "attempts": self.attempts,
             "last_error": self.last_error,
@@ -96,6 +105,7 @@ class QueuedApplication:
             tags=list(posting_data.get("tags", [])),
             felon_friendly=posting_data.get("felon_friendly"),
             apply_url=posting_data.get("apply_url"),
+            contact_email=posting_data.get("contact_email"),
         )
         apply_at = datetime.fromisoformat(payload["apply_at"])
         return cls(
@@ -104,6 +114,10 @@ class QueuedApplication:
             status=payload.get("status", "pending"),
             resume_path=payload.get("resume_path"),
             cover_letter_path=payload.get("cover_letter_path"),
+            resume_template=payload.get("resume_template", "traditional"),
+            cover_letter_template=payload.get("cover_letter_template", "traditional"),
+            custom_resume_template=payload.get("custom_resume_template"),
+            custom_cover_letter_template=payload.get("custom_cover_letter_template"),
             notes=list(payload.get("notes", [])),
             attempts=payload.get("attempts", 0),
             last_error=payload.get("last_error"),

--- a/src/jobofcron/cli.py
+++ b/src/jobofcron/cli.py
@@ -4,37 +4,63 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
+from .application_automation import AutomationDependencyError, DirectApplyAutomation
+from .application_queue import ApplicationQueue, QueuedApplication
+from .document_generation import generate_cover_letter, generate_resume
 from .job_matching import JobPosting, analyse_job_fit
 from .job_search import GoogleJobSearch
 from .profile import CandidateProfile
 from .scheduler import plan_schedule
 from .skills_inventory import SkillsInventory
 from .storage import Storage
+from .worker import JobAutomationWorker
 
 DEFAULT_STORAGE = Path("jobofcron_data.json")
 
 
-def load_or_init(storage_path: Path) -> tuple[CandidateProfile, SkillsInventory, Storage]:
+def slugify(*parts: str) -> str:
+    token = "-".join(part.strip().lower().replace(" ", "-") for part in parts if part)
+    cleaned = [ch for ch in token if ch.isalnum() or ch in {"-", "_"}]
+    return "".join(cleaned) or "application"
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - defensive conversion
+        raise SystemExit("Use ISO 8601 format for timestamps, e.g. 2024-05-01T09:30") from exc
+
+
+def load_or_init(
+    storage_path: Path,
+) -> tuple[CandidateProfile, SkillsInventory, ApplicationQueue, Storage]:
     storage = Storage(storage_path)
-    profile, inventory = storage.load()
+    profile, inventory, queue = storage.load()
 
     if profile is None:
         profile = CandidateProfile(name="Unknown", email="unknown@example.com")
     if inventory is None:
         inventory = SkillsInventory()
-    return profile, inventory, storage
+    if queue is None:
+        queue = ApplicationQueue()
+    return profile, inventory, queue, storage
 
 
-def save_and_exit(profile: CandidateProfile, inventory: SkillsInventory, storage: Storage) -> None:
-    storage.save(profile, inventory)
+def save_and_exit(
+    profile: CandidateProfile,
+    inventory: SkillsInventory,
+    queue: ApplicationQueue,
+    storage: Storage,
+) -> None:
+    storage.save(profile, inventory, queue)
 
 
 def cmd_show_profile(args: argparse.Namespace) -> None:
-    profile, inventory, _ = load_or_init(Path(args.storage))
+    profile, inventory, queue, _ = load_or_init(Path(args.storage))
     print("Profile:")
     print(f"  Name: {profile.name}")
     print(f"  Email: {profile.email}")
@@ -58,9 +84,19 @@ def cmd_show_profile(args: argparse.Namespace) -> None:
             f"  {record.name}: seen {record.occurrences}x, interviews {record.interviews}, offers {record.offers}"
         )
 
+    pending = queue.pending()
+    print("\nQueued applications:")
+    if not pending:
+        print("  None pending.")
+    else:
+        for task in pending:
+            print(
+                f"  - {task.job_id} => {task.posting.title} at {task.posting.company} scheduled for {task.apply_at.isoformat(timespec='minutes')}"
+            )
+
 
 def cmd_update_preferences(args: argparse.Namespace) -> None:
-    profile, inventory, storage = load_or_init(Path(args.storage))
+    profile, inventory, queue, storage = load_or_init(Path(args.storage))
     profile.job_preferences.update(
         min_salary=args.min_salary,
         locations=args.locations,
@@ -73,20 +109,20 @@ def cmd_update_preferences(args: argparse.Namespace) -> None:
         profile.email = args.email
     if args.phone:
         profile.phone = args.phone
-    save_and_exit(profile, inventory, storage)
+    save_and_exit(profile, inventory, queue, storage)
     print("Preferences updated.")
 
 
 def cmd_add_skill(args: argparse.Namespace) -> None:
-    profile, inventory, storage = load_or_init(Path(args.storage))
+    profile, inventory, queue, storage = load_or_init(Path(args.storage))
     profile.add_skill(args.skill)
     inventory.observe_skills([args.skill])
-    save_and_exit(profile, inventory, storage)
+    save_and_exit(profile, inventory, queue, storage)
     print(f"Skill '{args.skill}' added.")
 
 
 def cmd_plan(args: argparse.Namespace) -> None:
-    profile, inventory, _ = load_or_init(Path(args.storage))
+    profile, inventory, queue, _ = load_or_init(Path(args.storage))
     if len(args.titles) != len(args.companies):
         raise SystemExit("--titles and --companies must have the same length")
     jobs = [
@@ -105,7 +141,7 @@ def cmd_plan(args: argparse.Namespace) -> None:
 
 
 def cmd_analyze(args: argparse.Namespace) -> None:
-    profile, inventory, storage = load_or_init(Path(args.storage))
+    profile, inventory, queue, storage = load_or_init(Path(args.storage))
 
     if args.description is None and args.description_file is None:
         raise SystemExit("Provide either --description or --description-file")
@@ -120,11 +156,12 @@ def cmd_analyze(args: argparse.Namespace) -> None:
         description=description,
         tags=args.tags or [],
         felon_friendly=args.felon_friendly,
+        apply_url=args.apply_url,
     )
 
     assessment = analyse_job_fit(profile, posting)
     inventory.observe_skills(assessment.required_skills)
-    save_and_exit(profile, inventory, storage)
+    save_and_exit(profile, inventory, queue, storage)
 
     total_skills = len(assessment.required_skills)
     matched = len(assessment.matched_skills)
@@ -171,8 +208,168 @@ def cmd_analyze(args: argparse.Namespace) -> None:
         print("\nFelon-friendly signal: No clear information provided; follow up if this is a requirement.")
 
 
+def cmd_generate_documents(args: argparse.Namespace) -> None:
+    profile, inventory, queue, storage = load_or_init(Path(args.storage))
+
+    if args.description is None and args.description_file is None:
+        raise SystemExit("Provide either --description or --description-file")
+
+    description = args.description or Path(args.description_file).read_text(encoding="utf-8")
+    posting = JobPosting(
+        id=args.job_id,
+        title=args.title,
+        company=args.company,
+        location=args.location,
+        salary_text=args.salary,
+        description=description,
+        tags=args.tags or [],
+        felon_friendly=args.felon_friendly,
+        apply_url=args.apply_url,
+    )
+
+    assessment = analyse_job_fit(profile, posting)
+    inventory.observe_skills(assessment.required_skills)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    slug = slugify(args.job_id or posting.id or posting.title, posting.company)
+
+    resume_path = output_dir / f"{slug}_resume.md"
+    cover_path = output_dir / f"{slug}_cover_letter.md"
+
+    resume_path.write_text(generate_resume(profile, posting, assessment), encoding="utf-8")
+    cover_path.write_text(generate_cover_letter(profile, posting, assessment), encoding="utf-8")
+
+    print(f"Resume saved to {resume_path}")
+    print(f"Cover letter saved to {cover_path}")
+
+    if args.enqueue:
+        if not posting.apply_url:
+            raise SystemExit("--apply-url is required when enqueueing an application")
+        apply_at = parse_iso_datetime(args.apply_at) if args.apply_at else datetime.now()
+        task = QueuedApplication(
+            posting=posting,
+            apply_at=apply_at,
+            resume_path=str(resume_path),
+            cover_letter_path=str(cover_path),
+        )
+        queue.add(task)
+        print(f"Queued application {task.job_id} for {apply_at.isoformat(timespec='minutes')}")
+
+    save_and_exit(profile, inventory, queue, storage)
+
+
+def _load_description(args: argparse.Namespace) -> str:
+    if args.description is None and args.description_file is None:
+        raise SystemExit("Provide either --description or --description-file")
+    return args.description or Path(args.description_file).read_text(encoding="utf-8")
+
+
+def cmd_apply(args: argparse.Namespace) -> None:
+    profile, inventory, queue, storage = load_or_init(Path(args.storage))
+    automation = DirectApplyAutomation(headless=not args.no_headless, timeout=args.timeout)
+    task: Optional[QueuedApplication] = None
+    now = datetime.now()
+    resume_path: Optional[Path] = None
+    cover_path: Optional[Path] = None
+
+    if args.queue_id:
+        task = queue.get(args.queue_id)
+        if not task:
+            raise SystemExit(f"No queued application found with id {args.queue_id}")
+        posting = task.posting
+        resume_path = Path(task.resume_path) if task.resume_path else None
+        cover_path = Path(task.cover_letter_path) if task.cover_letter_path else None
+        assessment = analyse_job_fit(profile, posting)
+    else:
+        if not args.apply_url:
+            raise SystemExit("--apply-url is required when applying directly")
+        if not args.title or not args.company:
+            raise SystemExit("--title and --company are required when applying directly")
+        description = _load_description(args)
+        posting = JobPosting(
+            id=args.job_id,
+            title=args.title,
+            company=args.company,
+            location=args.location,
+            salary_text=args.salary,
+            description=description,
+            tags=args.tags or [],
+            felon_friendly=args.felon_friendly,
+            apply_url=args.apply_url,
+        )
+        assessment = analyse_job_fit(profile, posting)
+        inventory.observe_skills(assessment.required_skills)
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        resume_path = Path(args.resume) if args.resume else None
+        cover_path = Path(args.cover_letter) if args.cover_letter else None
+        if args.auto_documents:
+            slug = slugify(args.job_id or posting.id or posting.title, posting.company)
+            resume_path = output_dir / f"{slug}_resume.md"
+            cover_path = output_dir / f"{slug}_cover_letter.md"
+            resume_path.write_text(generate_resume(profile, posting, assessment), encoding="utf-8")
+            cover_path.write_text(generate_cover_letter(profile, posting, assessment), encoding="utf-8")
+            print(f"Generated resume at {resume_path}")
+            print(f"Generated cover letter at {cover_path}")
+
+    try:
+        submitted = automation.apply(
+            profile,
+            posting,
+            resume_path=resume_path,
+            cover_letter_path=cover_path,
+            dry_run=args.dry_run,
+        )
+        if submitted:
+            if args.dry_run:
+                print("Dry run complete; documents prepared without submitting the form.")
+                if task:
+                    task.notes.append(
+                        "Dry run executed via CLI; manual review/submission still pending."
+                    )
+            else:
+                print("Application submission routine completed.")
+                if task:
+                    task.mark_success()
+        else:
+            print("Submission sequence executed but no submit control was triggered.")
+            if task:
+                task.mark_failure("No submit button detected")
+                task.defer(now + timedelta(minutes=args.retry_minutes))
+    except AutomationDependencyError as exc:
+        print(f"Automation dependency missing: {exc}")
+        if task:
+            task.mark_failure(str(exc))
+            task.defer(now + timedelta(minutes=args.retry_minutes))
+    except Exception as exc:  # pragma: no cover - automation side effects
+        print(f"Automation failed: {exc}")
+        if task:
+            task.mark_failure(str(exc))
+            task.defer(now + timedelta(minutes=args.retry_minutes))
+    finally:
+        save_and_exit(profile, inventory, queue, storage)
+
+
+def cmd_worker(args: argparse.Namespace) -> None:
+    documents_dir = Path(args.documents_dir)
+    documents_dir.mkdir(parents=True, exist_ok=True)
+    worker = JobAutomationWorker(
+        Path(args.storage),
+        documents_dir=documents_dir,
+        headless=not args.no_headless,
+        timeout=args.timeout,
+        retry_delay=timedelta(minutes=args.retry_minutes),
+    )
+
+    if args.loop:
+        worker.run_forever(interval=args.interval, dry_run=args.dry_run)
+    else:
+        worker.run_once(dry_run=args.dry_run)
+
+
 def cmd_search(args: argparse.Namespace) -> None:
-    profile, _, _ = load_or_init(Path(args.storage))
+    profile, _, _, _ = load_or_init(Path(args.storage))
 
     location = args.location
     if not location:
@@ -261,7 +458,56 @@ def build_parser() -> argparse.ArgumentParser:
     analyze.set_defaults(felon_friendly=None)
     analyze.add_argument("--description")
     analyze.add_argument("--description-file")
+    analyze.add_argument("--apply-url")
     analyze.set_defaults(func=cmd_analyze)
+
+    documents = subparsers.add_parser(
+        "generate-docs",
+        help="Generate resume and cover letter drafts tailored to a posting",
+    )
+    documents.add_argument("--job-id")
+    documents.add_argument("--title", required=True)
+    documents.add_argument("--company", required=True)
+    documents.add_argument("--location")
+    documents.add_argument("--salary")
+    documents.add_argument("--tags", nargs="*")
+    documents.add_argument("--felon-friendly", dest="felon_friendly", action="store_true")
+    documents.add_argument("--no-felon-friendly", dest="felon_friendly", action="store_false")
+    documents.set_defaults(felon_friendly=None)
+    documents.add_argument("--description")
+    documents.add_argument("--description-file")
+    documents.add_argument("--apply-url")
+    documents.add_argument("--output-dir", default="generated_documents")
+    documents.add_argument("--enqueue", action="store_true")
+    documents.add_argument(
+        "--apply-at",
+        help="ISO 8601 timestamp for when the worker should submit the queued application",
+    )
+    documents.set_defaults(func=cmd_generate_documents)
+
+    apply_cmd = subparsers.add_parser("apply", help="Submit an application immediately")
+    apply_cmd.add_argument("--queue-id", help="Use a queued application id instead of providing job details")
+    apply_cmd.add_argument("--job-id")
+    apply_cmd.add_argument("--title")
+    apply_cmd.add_argument("--company")
+    apply_cmd.add_argument("--location")
+    apply_cmd.add_argument("--salary")
+    apply_cmd.add_argument("--tags", nargs="*")
+    apply_cmd.add_argument("--felon-friendly", dest="felon_friendly", action="store_true")
+    apply_cmd.add_argument("--no-felon-friendly", dest="felon_friendly", action="store_false")
+    apply_cmd.set_defaults(felon_friendly=None)
+    apply_cmd.add_argument("--description")
+    apply_cmd.add_argument("--description-file")
+    apply_cmd.add_argument("--apply-url")
+    apply_cmd.add_argument("--resume")
+    apply_cmd.add_argument("--cover-letter")
+    apply_cmd.add_argument("--auto-documents", action="store_true")
+    apply_cmd.add_argument("--output-dir", default="generated_documents")
+    apply_cmd.add_argument("--no-headless", action="store_true")
+    apply_cmd.add_argument("--timeout", type=int, default=90)
+    apply_cmd.add_argument("--dry-run", action="store_true")
+    apply_cmd.add_argument("--retry-minutes", type=int, default=60)
+    apply_cmd.set_defaults(func=cmd_apply)
 
     search = subparsers.add_parser(
         "search",
@@ -285,6 +531,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     search.add_argument("--verbose", action="store_true", help="Print search result snippets")
     search.set_defaults(func=cmd_search)
+
+    worker = subparsers.add_parser("worker", help="Process queued applications on a schedule")
+    worker.add_argument("--documents-dir", default="generated_documents")
+    worker.add_argument("--loop", action="store_true", help="Keep running instead of exiting after one pass")
+    worker.add_argument("--interval", type=int, default=300, help="Seconds to wait between polling runs")
+    worker.add_argument("--dry-run", action="store_true", help="Skip browser automation and only refresh documents")
+    worker.add_argument("--no-headless", action="store_true", help="Run the browser with a visible window")
+    worker.add_argument("--timeout", type=int, default=90, help="Playwright navigation timeout in seconds")
+    worker.add_argument("--retry-minutes", type=int, default=45, help="Minutes to wait before retrying failures")
+    worker.set_defaults(func=cmd_worker)
 
     return parser
 

--- a/src/jobofcron/cli.py
+++ b/src/jobofcron/cli.py
@@ -1,0 +1,145 @@
+"""Lightweight command line interface for interacting with Jobofcron."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from .profile import CandidateProfile
+from .scheduler import plan_schedule
+from .skills_inventory import SkillsInventory
+from .storage import Storage
+
+DEFAULT_STORAGE = Path("jobofcron_data.json")
+
+
+def load_or_init(storage_path: Path) -> tuple[CandidateProfile, SkillsInventory, Storage]:
+    storage = Storage(storage_path)
+    profile, inventory = storage.load()
+
+    if profile is None:
+        profile = CandidateProfile(name="Unknown", email="unknown@example.com")
+    if inventory is None:
+        inventory = SkillsInventory()
+    return profile, inventory, storage
+
+
+def save_and_exit(profile: CandidateProfile, inventory: SkillsInventory, storage: Storage) -> None:
+    storage.save(profile, inventory)
+
+
+def cmd_show_profile(args: argparse.Namespace) -> None:
+    profile, inventory, _ = load_or_init(Path(args.storage))
+    print("Profile:")
+    print(f"  Name: {profile.name}")
+    print(f"  Email: {profile.email}")
+    if profile.phone:
+        print(f"  Phone: {profile.phone}")
+    if profile.summary:
+        print(f"  Summary: {profile.summary}")
+    print("  Skills:")
+    for skill in profile.skills:
+        print(f"    - {skill}")
+    print("  Preferences:")
+    prefs = profile.job_preferences
+    print(f"    Min salary: {prefs.min_salary}")
+    print(f"    Locations: {', '.join(prefs.locations) if prefs.locations else 'None set'}")
+    print(f"    Domains: {', '.join(prefs.focus_domains) if prefs.focus_domains else 'None set'}")
+    print(f"    Felon friendly only: {'Yes' if prefs.felon_friendly_only else 'No'}")
+
+    print("\nTracked skills (demand vs. success):")
+    for record in inventory.sorted_by_opportunity():
+        print(
+            f"  {record.name}: seen {record.occurrences}x, interviews {record.interviews}, offers {record.offers}"
+        )
+
+
+def cmd_update_preferences(args: argparse.Namespace) -> None:
+    profile, inventory, storage = load_or_init(Path(args.storage))
+    profile.job_preferences.update(
+        min_salary=args.min_salary,
+        locations=args.locations,
+        focus_domains=args.domains,
+        felon_friendly_only=args.felon_friendly,
+    )
+    if args.name:
+        profile.name = args.name
+    if args.email:
+        profile.email = args.email
+    if args.phone:
+        profile.phone = args.phone
+    save_and_exit(profile, inventory, storage)
+    print("Preferences updated.")
+
+
+def cmd_add_skill(args: argparse.Namespace) -> None:
+    profile, inventory, storage = load_or_init(Path(args.storage))
+    profile.add_skill(args.skill)
+    inventory.observe_skills([args.skill])
+    save_and_exit(profile, inventory, storage)
+    print(f"Skill '{args.skill}' added.")
+
+
+def cmd_plan(args: argparse.Namespace) -> None:
+    profile, inventory, _ = load_or_init(Path(args.storage))
+    if len(args.titles) != len(args.companies):
+        raise SystemExit("--titles and --companies must have the same length")
+    jobs = [
+        {"id": idx + 1, "title": title, "company": company}
+        for idx, (title, company) in enumerate(zip(args.titles, args.companies))
+    ]
+    schedule = plan_schedule(
+        jobs,
+        start=datetime.now(),
+        min_interval_minutes=args.interval,
+        break_every=args.break_every,
+    )
+    print("Planned application times:")
+    for entry in schedule:
+        print(f"  {entry.apply_at.isoformat(timespec='minutes')} - {entry.job_title} @ {entry.company}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Jobofcron CLI")
+    parser.add_argument("--storage", default=str(DEFAULT_STORAGE))
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    show = subparsers.add_parser("show", help="Display the stored profile and skill stats")
+    show.set_defaults(func=cmd_show_profile)
+
+    prefs = subparsers.add_parser("prefs", help="Update profile and job preferences")
+    prefs.add_argument("--name")
+    prefs.add_argument("--email")
+    prefs.add_argument("--phone")
+    prefs.add_argument("--min-salary", dest="min_salary", type=int)
+    prefs.add_argument("--locations", nargs="*", default=None)
+    prefs.add_argument("--domains", nargs="*", default=None)
+    prefs.add_argument("--felon-friendly", dest="felon_friendly", action="store_true")
+    prefs.add_argument("--no-felon-friendly", dest="felon_friendly", action="store_false")
+    prefs.set_defaults(felon_friendly=None)
+    prefs.set_defaults(func=cmd_update_preferences)
+
+    add_skill = subparsers.add_parser("add-skill", help="Register a new skill")
+    add_skill.add_argument("skill")
+    add_skill.set_defaults(func=cmd_add_skill)
+
+    plan = subparsers.add_parser("plan", help="Plan application pacing for a batch of jobs")
+    plan.add_argument("--titles", nargs="+", required=True)
+    plan.add_argument("--companies", nargs="+", required=True)
+    plan.add_argument("--interval", type=int, default=10)
+    plan.add_argument("--break-every", dest="break_every", type=int, default=5)
+    plan.set_defaults(func=cmd_plan)
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jobofcron/document_generation.py
+++ b/src/jobofcron/document_generation.py
@@ -1,0 +1,139 @@
+"""Helpers for generating tailored resume and cover letter drafts."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List
+
+from .job_matching import JobPosting, MatchAssessment
+from .profile import CandidateProfile, Experience
+
+
+def _format_contact_block(profile: CandidateProfile) -> List[str]:
+    lines = [profile.name]
+    contact_bits: List[str] = [profile.email]
+    if profile.phone:
+        contact_bits.append(profile.phone)
+    lines.append(" | ".join(bit for bit in contact_bits if bit))
+    if profile.summary:
+        lines.append(profile.summary.strip())
+    return lines
+
+
+def _format_experience(experiences: Iterable[Experience]) -> List[str]:
+    lines: List[str] = []
+    sorted_experiences = sorted(experiences, key=lambda exp: exp.start_date, reverse=True)
+    for exp in sorted_experiences:
+        start = exp.start_date.strftime("%b %Y")
+        end = exp.end_date.strftime("%b %Y") if exp.end_date else "Present"
+        lines.append(f"{exp.role} — {exp.company} ({start} – {end})")
+        for achievement in exp.achievements or []:
+            lines.append(f"  • {achievement}")
+    return lines
+
+
+def generate_resume(
+    profile: CandidateProfile,
+    posting: JobPosting,
+    assessment: MatchAssessment,
+) -> str:
+    """Create a lightweight resume draft emphasising the matched skills."""
+
+    lines: List[str] = []
+    lines.extend(_format_contact_block(profile))
+    lines.append("")
+
+    lines.append(f"Target Role: {posting.title} at {posting.company}")
+    lines.append("")
+
+    if assessment.matched_skills:
+        lines.append("Key Qualifications")
+        for skill in assessment.matched_skills:
+            lines.append(f"  • Demonstrated expertise in {skill}")
+        lines.append("")
+
+    remaining_skills = [
+        skill
+        for skill in profile.skills
+        if skill.lower() not in {match.lower() for match in assessment.matched_skills}
+    ]
+    if remaining_skills:
+        lines.append("Additional Skills")
+        for skill in remaining_skills:
+            lines.append(f"  • {skill}")
+        lines.append("")
+
+    if profile.certifications:
+        lines.append("Certifications")
+        for cert in profile.certifications:
+            lines.append(f"  • {cert}")
+        lines.append("")
+
+    experience_lines = _format_experience(profile.experiences)
+    if experience_lines:
+        lines.append("Professional Experience")
+        lines.extend(experience_lines)
+        lines.append("")
+
+    if assessment.missing_skills:
+        lines.append("Development Targets")
+        for skill in assessment.missing_skills:
+            lines.append(f"  • Gather supporting stories for {skill} or pursue training")
+        lines.append("")
+
+    if profile.additional_notes:
+        lines.append("Additional Notes")
+        for topic, note in profile.additional_notes.items():
+            lines.append(f"  • {topic}: {note}")
+        lines.append("")
+
+    return "\n".join(line.rstrip() for line in lines).strip() + "\n"
+
+
+def generate_cover_letter(
+    profile: CandidateProfile,
+    posting: JobPosting,
+    assessment: MatchAssessment,
+) -> str:
+    """Create a conversational cover letter referencing the match assessment."""
+
+    today = datetime.now().strftime("%B %d, %Y")
+    lines: List[str] = [today, "", posting.company, "", "Dear Hiring Manager,"]
+
+    intro = (
+        f"I am excited to apply for the {posting.title} role with {posting.company}. "
+        "My background and focus areas align with the responsibilities highlighted in the description."
+    )
+    lines.extend(["", intro, ""])
+
+    if assessment.matched_skills:
+        lines.append("In my recent work I have:")
+        for skill in assessment.matched_skills[:5]:
+            lines.append(f"  • Delivered results that showcase {skill}.")
+        lines.append("")
+
+    if assessment.recommended_profile_updates:
+        lines.append("I have also prepared supporting materials that emphasise:")
+        for update in assessment.recommended_profile_updates[:5]:
+            lines.append(f"  • {update}")
+        lines.append("")
+
+    if assessment.missing_skills:
+        lines.append(
+            "Where the posting calls for emerging skills, I am proactively filling those gaps through research, mentorship, and hands-on projects."
+        )
+        lines.append("")
+
+    if assessment.salary_notes:
+        lines.append("I appreciate the transparency around compensation and would value a conversation to confirm mutual fit on salary expectations.")
+        lines.append("")
+
+    if assessment.location_notes:
+        lines.append("Location logistics are workable on my end, and I am prepared for remote collaboration when needed.")
+        lines.append("")
+
+    closing = (
+        "Thank you for your consideration. I welcome the chance to discuss how my experience can support your team and am happy to provide any additional information."
+    )
+    lines.extend([closing, "", "Sincerely,", profile.name])
+
+    return "\n".join(line.rstrip() for line in lines).strip() + "\n"

--- a/src/jobofcron/document_generation.py
+++ b/src/jobofcron/document_generation.py
@@ -1,11 +1,20 @@
 """Helpers for generating tailored resume and cover letter drafts."""
 from __future__ import annotations
 
+import os
 from datetime import datetime
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 from .job_matching import JobPosting, MatchAssessment
 from .profile import CandidateProfile, Experience
+
+
+class DocumentGenerationDependencyError(RuntimeError):
+    """Raised when optional AI dependencies are missing or misconfigured."""
+
+
+class DocumentGenerationError(RuntimeError):
+    """Raised when an AI provider fails to generate content."""
 
 
 def _format_contact_block(profile: CandidateProfile) -> List[str]:
@@ -137,3 +146,156 @@ def generate_cover_letter(
     lines.extend([closing, "", "Sincerely,", profile.name])
 
     return "\n".join(line.rstrip() for line in lines).strip() + "\n"
+
+
+class AIDocumentGenerator:
+    """Use a chat-completion provider to craft tailored documents."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.3,
+        system_prompt: Optional[str] = None,
+    ) -> None:
+        self._explicit_api_key = api_key
+        self.model = model
+        self.temperature = temperature
+        self.system_prompt = system_prompt or (
+            "You are an expert career coach who writes concise, accomplishment-focused job application materials. "
+            "Always return valid Markdown and emphasise the candidate's demonstrable impact."
+        )
+
+    def _resolve_api_key(self) -> str:
+        api_key = self._explicit_api_key or os.getenv("OPENAI_API_KEY") or os.getenv("JOBOFCRON_OPENAI_KEY")
+        if not api_key:
+            raise DocumentGenerationDependencyError(
+                "Set OPENAI_API_KEY (or JOBOFCRON_OPENAI_KEY) or pass api_key to AIDocumentGenerator."
+            )
+        return api_key
+
+    def _build_client(self):
+        api_key = self._resolve_api_key()
+        try:  # Preferred modern SDK path
+            from openai import OpenAI  # type: ignore
+
+            return OpenAI(api_key=api_key), True
+        except ModuleNotFoundError:
+            try:
+                import openai  # type: ignore
+            except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+                raise DocumentGenerationDependencyError(
+                    "Install the 'ai' optional dependency group (pip install jobofcron[ai])."
+                ) from exc
+            openai.api_key = api_key
+            return openai, False
+
+    def _profile_summary(self, profile: CandidateProfile) -> str:
+        experiences = []
+        for exp in profile.experiences:
+            start = exp.start_date.strftime("%Y")
+            end = exp.end_date.strftime("%Y") if exp.end_date else "Present"
+            achievements = "; ".join(exp.achievements or [])
+            experiences.append(
+                f"- {exp.role} at {exp.company} ({start}-{end}): {achievements or 'Impact-driven responsibilities.'}"
+            )
+        notes = []
+        if profile.additional_notes:
+            for topic, note in profile.additional_notes.items():
+                notes.append(f"- {topic}: {note}")
+        return "\n".join(
+            [
+                f"Name: {profile.name}",
+                f"Email: {profile.email}",
+                f"Phone: {profile.phone or 'n/a'}",
+                f"Summary: {profile.summary or 'n/a'}",
+                f"Skills: {', '.join(profile.skills) or 'n/a'}",
+                f"Certifications: {', '.join(profile.certifications) or 'n/a'}",
+                "Experience:",
+                *(experiences or ["- Not provided"]),
+                "Notes:",
+                *(notes or ["- None"]),
+            ]
+        )
+
+    def _posting_summary(self, posting: JobPosting, assessment: MatchAssessment) -> str:
+        return "\n".join(
+            [
+                f"Role: {posting.title}",
+                f"Company: {posting.company}",
+                f"Location: {posting.location or 'n/a'}",
+                f"Salary: {posting.salary_text or 'n/a'}",
+                f"Felon friendly: {posting.felon_friendly}",
+                f"Apply URL: {posting.apply_url or 'n/a'}",
+                "Description:",
+                posting.description.strip() or "n/a",
+                "Matched skills: " + ", ".join(assessment.matched_skills) if assessment.matched_skills else "Matched skills: n/a",
+                "Missing skills: " + ", ".join(assessment.missing_skills) if assessment.missing_skills else "Missing skills: n/a",
+                "Recommended focus: "
+                + ", ".join(assessment.recommended_profile_updates)
+                if assessment.recommended_profile_updates
+                else "Recommended focus: n/a",
+            ]
+        )
+
+    def _chat(self, prompt: str) -> str:
+        client, is_modern = self._build_client()
+        try:
+            if is_modern:
+                response = client.chat.completions.create(  # type: ignore[call-arg]
+                    model=self.model,
+                    temperature=self.temperature,
+                    messages=[
+                        {"role": "system", "content": self.system_prompt},
+                        {"role": "user", "content": prompt},
+                    ],
+                )
+                content = response.choices[0].message.content or ""
+            else:  # Legacy SDK path
+                response = client.ChatCompletion.create(  # type: ignore[attr-defined]
+                    model=self.model,
+                    temperature=self.temperature,
+                    messages=[
+                        {"role": "system", "content": self.system_prompt},
+                        {"role": "user", "content": prompt},
+                    ],
+                )
+                content = response["choices"][0]["message"]["content"]
+        except Exception as exc:  # pragma: no cover - depends on network/service
+            raise DocumentGenerationError(f"AI document generation failed: {exc}") from exc
+
+        return content.strip()
+
+    def generate_resume(
+        self,
+        profile: CandidateProfile,
+        posting: JobPosting,
+        assessment: MatchAssessment,
+    ) -> str:
+        prompt = (
+            "Craft a targeted one-page resume in Markdown. Use concise bullet points and highlight quantifiable impact.\n\n"
+            "Candidate details:\n"
+            f"{self._profile_summary(profile)}\n\n"
+            "Job posting details:\n"
+            f"{self._posting_summary(posting, assessment)}"
+        )
+        content = self._chat(prompt)
+        return content + ("\n" if not content.endswith("\n") else "")
+
+    def generate_cover_letter(
+        self,
+        profile: CandidateProfile,
+        posting: JobPosting,
+        assessment: MatchAssessment,
+    ) -> str:
+        prompt = (
+            "Write a persuasive cover letter in Markdown with greeting, two impact paragraphs, and a closing. "
+            "Reference matched skills and address any development areas constructively.\n\n"
+            "Candidate details:\n"
+            f"{self._profile_summary(profile)}\n\n"
+            "Job posting details:\n"
+            f"{self._posting_summary(posting, assessment)}"
+        )
+        content = self._chat(prompt)
+        return content + ("\n" if not content.endswith("\n") else "")

--- a/src/jobofcron/job_history.py
+++ b/src/jobofcron/job_history.py
@@ -1,0 +1,169 @@
+"""Track previously applied jobs to avoid duplicate submissions."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+from .job_matching import JobPosting
+
+
+def _normalise_text(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return " ".join(value.strip().lower().split())
+
+
+def _normalise_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    parsed = urlparse(url)
+    netloc = parsed.netloc.lower()
+    path = parsed.path.rstrip("/")
+    query = f"?{parsed.query}" if parsed.query else ""
+    if not netloc and not path:
+        return None
+    return f"url::{netloc}{path}{query}"
+
+
+def _combo_key(title: Optional[str], company: Optional[str]) -> Optional[str]:
+    title_key = _normalise_text(title)
+    company_key = _normalise_text(company)
+    if not title_key and not company_key:
+        return None
+    return f"role::{company_key}::{title_key}"
+
+
+@dataclass
+class AppliedJobRecord:
+    """Metadata describing when a job was last actioned."""
+
+    key: str
+    title: str
+    company: str
+    apply_url: Optional[str]
+    first_seen_at: datetime
+    last_seen_at: datetime
+    last_status: Optional[str] = None
+    occurrences: int = 1
+
+    def touch(self, *, status: Optional[str] = None) -> None:
+        self.last_seen_at = datetime.now()
+        if status:
+            self.last_status = status
+        self.occurrences += 1
+
+    def to_dict(self) -> dict:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "company": self.company,
+            "apply_url": self.apply_url,
+            "first_seen_at": self.first_seen_at.isoformat(),
+            "last_seen_at": self.last_seen_at.isoformat(),
+            "last_status": self.last_status,
+            "occurrences": self.occurrences,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AppliedJobRecord":
+        return cls(
+            key=data["key"],
+            title=data.get("title", ""),
+            company=data.get("company", ""),
+            apply_url=data.get("apply_url"),
+            first_seen_at=datetime.fromisoformat(data["first_seen_at"]),
+            last_seen_at=datetime.fromisoformat(data["last_seen_at"]),
+            last_status=data.get("last_status"),
+            occurrences=int(data.get("occurrences", 1)),
+        )
+
+
+@dataclass
+class AppliedJobRegistry:
+    """Lookup helper to detect if a job has already been actioned."""
+
+    records: Dict[str, AppliedJobRecord] = field(default_factory=dict)
+    aliases: Dict[str, str] = field(default_factory=dict)
+
+    def _keys_for(self, posting: JobPosting) -> List[str]:
+        keys: List[str] = []
+        url_key = _normalise_url(posting.apply_url)
+        if url_key:
+            keys.append(url_key)
+        combo = _combo_key(posting.title, posting.company)
+        if combo:
+            keys.append(combo)
+        if not keys:
+            fallback = _normalise_text(posting.title) or "unknown"
+            keys.append(f"fallback::{fallback}")
+        return keys
+
+    def find(self, posting: JobPosting) -> Optional[AppliedJobRecord]:
+        for key in self._keys_for(posting):
+            target = self.aliases.get(key, key)
+            if target in self.records:
+                return self.records[target]
+        return None
+
+    def record(self, posting: JobPosting, *, status: Optional[str] = None) -> AppliedJobRecord:
+        now = datetime.now()
+        keys = self._keys_for(posting)
+        existing = None
+        for key in keys:
+            target = self.aliases.get(key)
+            if target and target in self.records:
+                existing = self.records[target]
+                break
+
+        if existing:
+            existing.touch(status=status)
+            if status and not existing.last_status:
+                existing.last_status = status
+            for key in keys:
+                self.aliases[key] = existing.key
+            if posting.apply_url:
+                existing.apply_url = posting.apply_url
+            if posting.company:
+                existing.company = posting.company
+            if posting.title:
+                existing.title = posting.title
+            return existing
+
+        primary_key = keys[0]
+        record = AppliedJobRecord(
+            key=primary_key,
+            title=posting.title,
+            company=posting.company,
+            apply_url=posting.apply_url,
+            first_seen_at=now,
+            last_seen_at=now,
+            last_status=status,
+        )
+        self.records[primary_key] = record
+        for key in keys:
+            self.aliases[key] = primary_key
+        return record
+
+    def to_snapshot(self) -> dict:
+        return {
+            "records": [record.to_dict() for record in self.records.values()],
+            "aliases": dict(self.aliases),
+        }
+
+    @classmethod
+    def from_snapshot(cls, payload: Optional[dict]) -> "AppliedJobRegistry":
+        if not payload:
+            return cls()
+        records = {
+            entry["key"]: AppliedJobRecord.from_dict(entry)
+            for entry in payload.get("records", [])
+            if "key" in entry
+        }
+        aliases = {key: value for key, value in (payload.get("aliases") or {}).items() if value in records}
+        return cls(records=records, aliases=aliases)
+
+    def known_keys(self) -> Iterable[str]:
+        return self.aliases.keys()
+

--- a/src/jobofcron/job_matching.py
+++ b/src/jobofcron/job_matching.py
@@ -44,6 +44,7 @@ class JobPosting:
     description: str = ""
     tags: List[str] = field(default_factory=list)
     felon_friendly: Optional[bool] = None
+    apply_url: Optional[str] = None
 
 
 @dataclass

--- a/src/jobofcron/job_matching.py
+++ b/src/jobofcron/job_matching.py
@@ -1,0 +1,251 @@
+"""Utilities for evaluating how well a profile matches a job posting.
+
+The matching logic is deliberately heuristic driven so it can run without
+external dependencies. It focuses on surfacing the questions the automation
+should ask the user before submitting an application as well as the resume or
+cover letter updates that would strengthen the submission.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Iterable, List, Optional, Tuple
+
+from .profile import CandidateProfile
+
+
+# Phrases that usually introduce skill requirements within a description.
+SKILL_HINT_PATTERNS = (
+    r"experience with ([^.;\n]+)",
+    r"experience in ([^.;\n]+)",
+    r"proficiency in ([^.;\n]+)",
+    r"proficient in ([^.;\n]+)",
+    r"skilled in ([^.;\n]+)",
+    r"knowledge of ([^.;\n]+)",
+    r"familiar(?:ity)? with ([^.;\n]+)",
+    r"background in ([^.;\n]+)",
+    r"skills?: ([^\n]+)",
+    r"requirements?: ([^\n]+)",
+)
+
+
+SPLIT_PATTERN = re.compile(r",|;|\band\b|\bor\b|\bsuch as\b|\bincluding\b|\bfor example\b", re.IGNORECASE)
+
+
+@dataclass
+class JobPosting:
+    """Minimal representation of a job posting."""
+
+    title: str
+    company: str
+    id: Optional[str] = None
+    location: Optional[str] = None
+    salary_text: Optional[str] = None
+    description: str = ""
+    tags: List[str] = field(default_factory=list)
+    felon_friendly: Optional[bool] = None
+
+
+@dataclass
+class MatchAssessment:
+    """Result of comparing a profile against a job posting."""
+
+    required_skills: List[str]
+    matched_skills: List[str]
+    missing_skills: List[str]
+    match_score: float
+    recommended_questions: List[str] = field(default_factory=list)
+    recommended_profile_updates: List[str] = field(default_factory=list)
+    salary_notes: List[str] = field(default_factory=list)
+    meets_salary: Optional[bool] = None
+    location_notes: List[str] = field(default_factory=list)
+    meets_location: Optional[bool] = None
+    felon_friendly: Optional[bool] = None
+
+
+def _normalise_skill_name(skill: str) -> str:
+    cleaned = skill.strip().strip("-•·:")
+    cleaned = re.sub(
+        r"^(?:experience|experiences|background|knowledge|familiarity|familiar|proficiency|proficient|skilled)\s+"
+        r"(?:in|with|of)?\s+",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(r"\b(?:is\s+preferred|preferred|is\s+required|required|a\s+plus|plus)\b.*$", "", cleaned, flags=re.IGNORECASE)
+    return cleaned.strip()
+
+
+def _split_skills(phrase: str) -> Iterable[str]:
+    phrase = phrase.replace("/", ",")
+    phrase = re.sub(r"\(.*?\)", "", phrase)
+    for part in SPLIT_PATTERN.split(phrase):
+        token = _normalise_skill_name(part)
+        if not token:
+            continue
+        yield token
+
+
+def _extract_skills_from_description(description: str) -> List[str]:
+    skills: List[str] = []
+    seen = set()
+    for pattern in SKILL_HINT_PATTERNS:
+        for match in re.finditer(pattern, description, flags=re.IGNORECASE):
+            for skill in _split_skills(match.group(1)):
+                key = skill.lower()
+                if key not in seen:
+                    seen.add(key)
+                    skills.append(skill)
+
+    for line in description.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("-", "*", "•")):
+            bullet = stripped.lstrip("-*• ")
+            if any(keyword in bullet.lower() for keyword in ("experience", "knowledge", "skill", "familiar")):
+                for skill in _split_skills(bullet):
+                    key = skill.lower()
+                    if key not in seen:
+                        seen.add(key)
+                        skills.append(skill)
+
+    return skills
+
+
+def extract_required_skills(posting: JobPosting) -> List[str]:
+    """Return a deduplicated ordered list of skills mentioned in the posting."""
+
+    description_skills = _extract_skills_from_description(posting.description)
+    skills: List[str] = []
+    seen = set()
+    for skill in list(posting.tags) + description_skills:
+        token = _normalise_skill_name(skill)
+        if not token:
+            continue
+        key = token.lower()
+        if key not in seen:
+            seen.add(key)
+            skills.append(token)
+    return skills
+
+
+def _parse_salary_numbers(text: str) -> Tuple[Optional[int], Optional[int]]:
+    numbers: List[int] = []
+    for match in re.finditer(r"\$?\s*(\d[\d,]*)(?:\s*([kK]))?", text):
+        raw_number = match.group(1).replace(",", "")
+        try:
+            value = int(raw_number)
+        except ValueError:
+            continue
+        if match.group(2):
+            value *= 1000
+        numbers.append(value)
+
+    if not numbers:
+        return None, None
+
+    low = min(numbers)
+    high = max(numbers)
+    return low, high
+
+
+def _infer_felon_friendly(description: str) -> Optional[bool]:
+    text = description.lower()
+    positive = any(keyword in text for keyword in ("felon friendly", "felony friendly", "second chance", "justice-involved"))
+    negative = any(keyword in text for keyword in ("must pass background", "no felonies", "no felony", "clean record required"))
+    if positive and not negative:
+        return True
+    if negative and not positive:
+        return False
+    return None
+
+
+def analyse_job_fit(profile: CandidateProfile, posting: JobPosting) -> MatchAssessment:
+    """Compare the profile with the job posting and surface actionable gaps."""
+
+    required_skills = extract_required_skills(posting)
+    profile_skills = {skill.lower(): skill for skill in profile.skills}
+
+    matched: List[str] = []
+    missing: List[str] = []
+    for skill in required_skills:
+        key = skill.lower()
+        if key in profile_skills:
+            matched.append(profile_skills[key])
+        else:
+            missing.append(skill)
+
+    total = len(required_skills) or 1
+    score = len(matched) / total
+
+    questions: List[str] = []
+    updates: List[str] = []
+    for skill in missing:
+        questions.append(f"Do you have experience with {skill}? Provide anecdotes to include in the tailored resume/cover letter.")
+    for skill in matched:
+        updates.append(f"Highlight recent wins that showcase {skill} in the customised documents.")
+
+    salary_notes: List[str] = []
+    meets_salary: Optional[bool] = None
+    min_required = profile.job_preferences.min_salary
+    salary_source = posting.salary_text or posting.description
+    if min_required is not None:
+        if salary_source:
+            low, high = _parse_salary_numbers(salary_source)
+            if low is None and high is None:
+                salary_notes.append("Posting does not advertise compensation; confirm it meets your minimum.")
+            else:
+                meets_salary = (high or low or 0) >= min_required
+                if not meets_salary:
+                    salary_notes.append(
+                        f"Minimum salary preference ${min_required:,} may exceed the posting range ({low:,} - {high:,} if known)."
+                    )
+        else:
+            salary_notes.append("No salary details were provided; verify against your minimum expectation.")
+    elif posting.salary_text:
+        salary_notes.append("Profile lacks a minimum salary preference; consider setting one based on this posting.")
+
+    location_notes: List[str] = []
+    meets_location: Optional[bool] = None
+    preferred_locations = [loc.strip().casefold() for loc in profile.job_preferences.locations if loc.strip()]
+    posting_location = posting.location.strip() if posting.location else None
+    if preferred_locations:
+        if posting_location:
+            location_key = posting_location.casefold()
+            matches = any(
+                pref in location_key or location_key in pref or (pref == "remote" and "remote" in location_key)
+                for pref in preferred_locations
+            )
+            meets_location = matches
+            if not matches:
+                location_notes.append(
+                    "Posting location does not match saved preferences; decide if you want to expand your target areas."
+                )
+        else:
+            location_notes.append("Posting omitted location details; confirm they align with your preferences.")
+    elif posting_location:
+        location_notes.append("Profile has no saved locations; record preferred markets if this posting is appealing.")
+
+    felon_friendly = posting.felon_friendly
+    if felon_friendly is None:
+        felon_friendly = _infer_felon_friendly(posting.description)
+    if profile.job_preferences.felon_friendly_only and felon_friendly is not True:
+        questions.append(
+            "Listing may not clearly state it is felon friendly; research or contact the employer before applying."
+        )
+
+    return MatchAssessment(
+        required_skills=required_skills,
+        matched_skills=matched,
+        missing_skills=missing,
+        match_score=score,
+        recommended_questions=questions,
+        recommended_profile_updates=updates,
+        salary_notes=salary_notes,
+        meets_salary=meets_salary,
+        location_notes=location_notes,
+        meets_location=meets_location,
+        felon_friendly=felon_friendly,
+    )
+

--- a/src/jobofcron/job_matching.py
+++ b/src/jobofcron/job_matching.py
@@ -45,6 +45,7 @@ class JobPosting:
     tags: List[str] = field(default_factory=list)
     felon_friendly: Optional[bool] = None
     apply_url: Optional[str] = None
+    contact_email: Optional[str] = None
 
 
 @dataclass

--- a/src/jobofcron/job_search.py
+++ b/src/jobofcron/job_search.py
@@ -12,6 +12,8 @@ CLI (e.g. inside a web worker or an orchestration flow).
 """
 from __future__ import annotations
 
+import html
+import re
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
 from urllib.parse import urlparse
@@ -134,3 +136,82 @@ class GoogleJobSearch:
         """Return only results that appear to come from company-owned domains."""
 
         return [result for result in results if result.is_company_site]
+
+
+class CraigslistSearch:
+    """Scrape Craigslist job listings for a region using the public HTML pages."""
+
+    def __init__(
+        self,
+        *,
+        location: str,
+        site_hint: Optional[str] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.location = location
+        self.base_url = self._resolve_base(site_hint or location)
+        self.session = session or requests.Session()
+
+    @staticmethod
+    def _resolve_base(hint: str) -> str:
+        slug = hint.strip().lower().replace(" ", "").replace(",", "")
+        if not slug:
+            slug = "www"
+        if slug.startswith("http://") or slug.startswith("https://"):
+            return slug.rstrip("/")
+        if ".craigslist.org" in slug:
+            return f"https://{slug.rstrip('/')}"
+        return f"https://{slug}.craigslist.org"
+
+    def search_jobs(
+        self,
+        *,
+        title: str,
+        max_results: int = 10,
+        remote: bool = False,
+        extra_terms: Optional[Iterable[str]] = None,
+    ) -> List[SearchResult]:
+        query_parts = [title]
+        if remote:
+            query_parts.append("remote")
+        if extra_terms:
+            query_parts.extend(term for term in extra_terms if term)
+        query = " ".join(part for part in query_parts if part)
+
+        url = f"{self.base_url}/search/jjj"
+        headers = {"User-Agent": "jobofcron-bot/0.1"}
+        response = self.session.get(url, params={"query": query, "sort": "date"}, headers=headers, timeout=30)
+        response.raise_for_status()
+        return self._parse_results(response.text)[:max_results]
+
+    def _parse_results(self, html_text: str) -> List[SearchResult]:
+        results: List[SearchResult] = []
+        anchor_pattern = re.compile(
+            r"<a[^>]+href=\"(?P<link>[^\"]+)\"[^>]*class=\"[^\"]*(?:result-title|titlestring)[^\"]*\"[^>]*>(?P<title>.*?)</a>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        snippet_pattern = re.compile(
+            r"<span[^>]+class=\"[^\"]*(?:result-meta|meta)[^\"]*\"[^>]*>(?P<snippet>.*?)</span>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        for match in anchor_pattern.finditer(html_text):
+            raw_title = re.sub(r"<.*?>", "", match.group("title"))
+            title = html.unescape(raw_title).strip()
+            link = html.unescape(match.group("link"))
+            snippet = ""
+            snippet_match = snippet_pattern.search(html_text, match.end(), match.end() + 400)
+            if snippet_match:
+                snippet_raw = re.sub(r"<.*?>", " ", snippet_match.group("snippet"))
+                snippet = re.sub(r"\s+", " ", html.unescape(snippet_raw)).strip()
+
+            source = GoogleJobSearch._normalise_domain(link)
+            results.append(
+                SearchResult(
+                    title=title,
+                    link=link,
+                    snippet=snippet,
+                    source=source or "craigslist",
+                    is_company_site=True,
+                )
+            )
+        return results

--- a/src/jobofcron/job_search.py
+++ b/src/jobofcron/job_search.py
@@ -1,0 +1,136 @@
+"""Helpers for discovering job postings via Google search results.
+
+This module provides a light wrapper around the SerpAPI Google Search endpoint
+so we can query for job postings and then prioritise company career pages over
+job-board aggregators like Indeed. The idea is to locate direct-apply links that
+minimise the risk of automated filters catching us for coming from an external
+board.
+
+The implementation is intentionally thin: we only depend on ``requests`` and we
+work with plain dataclasses so the search component can be reused outside of the
+CLI (e.g. inside a web worker or an orchestration flow).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+from urllib.parse import urlparse
+
+import requests
+
+SERPAPI_SEARCH_URL = "https://serpapi.com/search.json"
+
+
+AGGREGATOR_DOMAINS = {
+    "indeed.com",
+    "linkedin.com",
+    "glassdoor.com",
+    "ziprecruiter.com",
+    "monster.com",
+    "simplyhired.com",
+    "snagajob.com",
+    "careerbuilder.com",
+    "lever.co",
+    "greenhouse.io",
+    "angel.co",
+}
+
+
+@dataclass
+class SearchResult:
+    """A single Google search result parsed into structured data."""
+
+    title: str
+    link: str
+    snippet: str
+    source: str
+    is_company_site: bool
+
+
+class GoogleJobSearch:
+    """Search Google via SerpAPI and highlight company career pages."""
+
+    def __init__(self, api_key: str, *, engine: str = "google", session: Optional[requests.Session] = None) -> None:
+        if not api_key:
+            raise ValueError("An API key is required to query SerpAPI")
+        self.api_key = api_key
+        self.engine = engine
+        self.session = session or requests.Session()
+
+    def search_jobs(
+        self,
+        *,
+        title: str,
+        location: str,
+        max_results: int = 10,
+        remote: bool = False,
+        extra_terms: Optional[Iterable[str]] = None,
+    ) -> List[SearchResult]:
+        """Run a Google search tailored for job discovery.
+
+        Args:
+            title: Role title or keywords to search for.
+            location: Geographic location to append to the query.
+            max_results: Maximum number of search results to return.
+            remote: Whether to append a remote-work hint to the query.
+            extra_terms: Optional additional search tokens (e.g. company
+                domains, industry keywords).
+        """
+
+        query_parts = [title, "job", location]
+        if remote:
+            query_parts.append("remote")
+        if extra_terms:
+            query_parts.extend(term for term in extra_terms if term)
+        query = " ".join(part for part in query_parts if part)
+
+        params = {
+            "engine": self.engine,
+            "q": query,
+            "api_key": self.api_key,
+            "num": min(max_results, 20),
+        }
+
+        response = self.session.get(SERPAPI_SEARCH_URL, params=params, timeout=30)
+        response.raise_for_status()
+        payload = response.json()
+        return self.parse_results(payload)[:max_results]
+
+    @staticmethod
+    def _normalise_domain(url: str) -> str:
+        parsed = urlparse(url)
+        domain = parsed.netloc.lower()
+        return domain.lstrip("www.")
+
+    @classmethod
+    def parse_results(cls, payload: dict) -> List[SearchResult]:
+        """Convert a SerpAPI payload into :class:`SearchResult` objects."""
+
+        results: List[SearchResult] = []
+        for entry in payload.get("organic_results", []):
+            link = entry.get("link") or ""
+            title = entry.get("title") or ""
+            snippet = entry.get("snippet") or ""
+            domain = cls._normalise_domain(link)
+            is_company = bool(domain) and not cls._is_aggregator(domain)
+            results.append(
+                SearchResult(
+                    title=title.strip(),
+                    link=link,
+                    snippet=snippet.strip(),
+                    source=domain or "unknown",
+                    is_company_site=is_company,
+                )
+            )
+        return results
+
+    @staticmethod
+    def _is_aggregator(domain: str) -> bool:
+        domain = domain.lower()
+        return any(domain == agg or domain.endswith(f".{agg}") for agg in AGGREGATOR_DOMAINS)
+
+    @classmethod
+    def filter_direct_apply(cls, results: Iterable[SearchResult]) -> List[SearchResult]:
+        """Return only results that appear to come from company-owned domains."""
+
+        return [result for result in results if result.is_company_site]

--- a/src/jobofcron/profile.py
+++ b/src/jobofcron/profile.py
@@ -24,12 +24,14 @@ class JobPreference:
             searches.
         felon_friendly_only: Whether to restrict searches to postings that
             indicate they are open to candidates with felonies.
+        blacklisted_companies: Employers to skip automatically.
     """
 
     min_salary: Optional[int] = None
     locations: List[str] = field(default_factory=list)
     focus_domains: List[str] = field(default_factory=list)
     felon_friendly_only: bool = False
+    blacklisted_companies: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, object]:
         """Serialise the preference to a plain dictionary."""
@@ -43,6 +45,7 @@ class JobPreference:
         locations: Optional[List[str]] = None,
         focus_domains: Optional[List[str]] = None,
         felon_friendly_only: Optional[bool] = None,
+        blacklisted_companies: Optional[List[str]] = None,
     ) -> None:
         """Update the preference in-place with non-``None`` values."""
 
@@ -54,6 +57,8 @@ class JobPreference:
             self.focus_domains = focus_domains
         if felon_friendly_only is not None:
             self.felon_friendly_only = felon_friendly_only
+        if blacklisted_companies is not None:
+            self.blacklisted_companies = blacklisted_companies
 
 
 @dataclass
@@ -140,6 +145,7 @@ class CandidateProfile:
             locations=list(pref_data.get("locations", [])),
             focus_domains=list(pref_data.get("focus_domains", [])),
             felon_friendly_only=pref_data.get("felon_friendly_only", False),
+            blacklisted_companies=list(pref_data.get("blacklisted_companies", [])),
         )
 
         experiences = [

--- a/src/jobofcron/profile.py
+++ b/src/jobofcron/profile.py
@@ -1,0 +1,166 @@
+"""Core data models for representing the candidate profile and job preferences.
+
+These helpers focus on storing structured data that other services (matching,
+application scheduling, document generation) can consume. They intentionally
+avoid persistence and I/O so they can be reused in different environments
+(e.g. CLI, web API, background worker).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from typing import Dict, List, Optional
+
+
+@dataclass
+class JobPreference:
+    """Filters used when searching for roles.
+
+    Attributes:
+        min_salary: Minimum annual salary in USD the user will consider.
+        locations: Preferred geographic locations. "Remote" should be included
+            explicitly when remote work is desired.
+        focus_domains: Industries or domains to prioritise when running
+            searches.
+        felon_friendly_only: Whether to restrict searches to postings that
+            indicate they are open to candidates with felonies.
+    """
+
+    min_salary: Optional[int] = None
+    locations: List[str] = field(default_factory=list)
+    focus_domains: List[str] = field(default_factory=list)
+    felon_friendly_only: bool = False
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the preference to a plain dictionary."""
+
+        return asdict(self)
+
+    def update(
+        self,
+        *,
+        min_salary: Optional[int] | None = None,
+        locations: Optional[List[str]] = None,
+        focus_domains: Optional[List[str]] = None,
+        felon_friendly_only: Optional[bool] = None,
+    ) -> None:
+        """Update the preference in-place with non-``None`` values."""
+
+        if min_salary is not None:
+            self.min_salary = min_salary
+        if locations is not None:
+            self.locations = locations
+        if focus_domains is not None:
+            self.focus_domains = focus_domains
+        if felon_friendly_only is not None:
+            self.felon_friendly_only = felon_friendly_only
+
+
+@dataclass
+class Experience:
+    """Represents a single work history item."""
+
+    company: str
+    role: str
+    start_date: datetime
+    end_date: Optional[datetime] = None
+    achievements: List[str] = field(default_factory=list)
+
+    def current(self) -> bool:
+        return self.end_date is None or self.end_date > datetime.now()
+
+
+@dataclass
+class CandidateProfile:
+    """Aggregate model describing the user applying to jobs."""
+
+    name: str
+    email: str
+    phone: Optional[str] = None
+    summary: Optional[str] = None
+    skills: List[str] = field(default_factory=list)
+    certifications: List[str] = field(default_factory=list)
+    experiences: List[Experience] = field(default_factory=list)
+    job_preferences: JobPreference = field(default_factory=JobPreference)
+    additional_notes: Dict[str, str] = field(default_factory=dict)
+
+    def add_skill(self, skill: str) -> None:
+        """Add a skill if it is not already present (case insensitive)."""
+
+        normalised = skill.strip()
+        if not normalised:
+            return
+
+        if normalised.lower() not in {s.lower() for s in self.skills}:
+            self.skills.append(normalised)
+
+    def record_experience(self, experience: Experience) -> None:
+        """Append a new work history entry."""
+
+        self.experiences.append(experience)
+
+    def update_contact(self, *, email: Optional[str] = None, phone: Optional[str] = None) -> None:
+        """Update contact fields with any provided values."""
+
+        if email:
+            self.email = email
+        if phone:
+            self.phone = phone
+
+    def add_note(self, topic: str, note: str) -> None:
+        """Store free-form notes (e.g. felony considerations, availability)."""
+
+        if topic.strip():
+            self.additional_notes[topic.strip()] = note.strip()
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a serialisable representation of the profile."""
+
+        profile = asdict(self)
+        profile["experiences"] = [
+            {
+                "company": exp.company,
+                "role": exp.role,
+                "start_date": exp.start_date.isoformat(),
+                "end_date": exp.end_date.isoformat() if exp.end_date else None,
+                "achievements": list(exp.achievements),
+            }
+            for exp in self.experiences
+        ]
+        profile["job_preferences"] = self.job_preferences.to_dict()
+        return profile
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "CandidateProfile":
+        """Hydrate a :class:`CandidateProfile` from saved data."""
+
+        pref_data = data.get("job_preferences", {})
+        job_preferences = JobPreference(
+            min_salary=pref_data.get("min_salary"),
+            locations=list(pref_data.get("locations", [])),
+            focus_domains=list(pref_data.get("focus_domains", [])),
+            felon_friendly_only=pref_data.get("felon_friendly_only", False),
+        )
+
+        experiences = [
+            Experience(
+                company=exp["company"],
+                role=exp["role"],
+                start_date=datetime.fromisoformat(exp["start_date"]),
+                end_date=datetime.fromisoformat(exp["end_date"]) if exp.get("end_date") else None,
+                achievements=list(exp.get("achievements", [])),
+            )
+            for exp in data.get("experiences", [])
+        ]
+
+        return cls(
+            name=data["name"],
+            email=data["email"],
+            phone=data.get("phone"),
+            summary=data.get("summary"),
+            skills=list(data.get("skills", [])),
+            certifications=list(data.get("certifications", [])),
+            experiences=experiences,
+            job_preferences=job_preferences,
+            additional_notes=dict(data.get("additional_notes", {})),
+        )

--- a/src/jobofcron/scheduler.py
+++ b/src/jobofcron/scheduler.py
@@ -1,0 +1,57 @@
+"""Application scheduler utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import List, Sequence
+
+
+@dataclass
+class ScheduledApplication:
+    job_id: str
+    job_title: str
+    company: str
+    apply_at: datetime
+
+
+def plan_schedule(
+    jobs: Sequence[dict],
+    *,
+    start: datetime,
+    min_interval_minutes: int = 10,
+    break_every: int = 5,
+    break_duration: timedelta = timedelta(minutes=30),
+) -> List[ScheduledApplication]:
+    """Create a paced schedule for applying to jobs.
+
+    Args:
+        jobs: Iterable of job dictionaries with ``id``, ``title`` and ``company``.
+        start: When to begin applying.
+        min_interval_minutes: Minimum spacing between applications.
+        break_every: After how many applications to insert a break.
+        break_duration: Duration of the break.
+    """
+
+    if min_interval_minutes <= 0:
+        raise ValueError("min_interval_minutes must be positive")
+    if break_every <= 0:
+        raise ValueError("break_every must be positive")
+
+    schedule: List[ScheduledApplication] = []
+    current_time = start
+    interval = timedelta(minutes=min_interval_minutes)
+
+    for index, job in enumerate(jobs, start=1):
+        schedule.append(
+            ScheduledApplication(
+                job_id=str(job.get("id")),
+                job_title=job.get("title", ""),
+                company=job.get("company", ""),
+                apply_at=current_time,
+            )
+        )
+        current_time += interval
+        if index % break_every == 0:
+            current_time += break_duration
+
+    return schedule

--- a/src/jobofcron/skills_inventory.py
+++ b/src/jobofcron/skills_inventory.py
@@ -1,0 +1,108 @@
+"""Skill inventory utilities.
+
+The inventory collects skills, certifications, and personal notes discovered
+while applying for jobs. It can surface growth opportunities by tracking how
+frequently each skill appears in matching job descriptions and which ones lead
+to interviews or offers.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class SkillRecord:
+    """Tracks how often a skill is observed and its outcomes."""
+
+    name: str
+    occurrences: int = 0
+    interviews: int = 0
+    offers: int = 0
+    notes: List[str] = field(default_factory=list)
+
+    def register_observation(self, count: int = 1) -> None:
+        self.occurrences += count
+
+    def record_interview(self) -> None:
+        self.interviews += 1
+
+    def record_offer(self) -> None:
+        self.offers += 1
+
+    def add_note(self, note: str) -> None:
+        if note.strip():
+            self.notes.append(note.strip())
+
+
+class SkillsInventory:
+    """Manages a collection of :class:`SkillRecord` instances."""
+
+    def __init__(self) -> None:
+        self._skills: Dict[str, SkillRecord] = {}
+
+    def ensure(self, skill_name: str) -> SkillRecord:
+        key = skill_name.lower().strip()
+        if not key:
+            raise ValueError("Skill name cannot be blank")
+        if key not in self._skills:
+            self._skills[key] = SkillRecord(name=skill_name.strip())
+        return self._skills[key]
+
+    def observe_skills(self, skills: Iterable[str]) -> None:
+        cleaned = [skill.strip() for skill in skills if skill and skill.strip()]
+        counts = Counter(skill.lower() for skill in cleaned)
+        for key, count in counts.items():
+            record = self._skills.get(key)
+            if record is None:
+                original = next(skill for skill in cleaned if skill.lower() == key)
+                record = SkillRecord(name=original)
+                self._skills[key] = record
+            record.register_observation(count)
+
+    def record_interview(self, skill_name: str) -> None:
+        self.ensure(skill_name).record_interview()
+
+    def record_offer(self, skill_name: str) -> None:
+        self.ensure(skill_name).record_offer()
+
+    def add_note(self, skill_name: str, note: str) -> None:
+        self.ensure(skill_name).add_note(note)
+
+    def to_snapshot(self) -> Dict[str, Dict[str, object]]:
+        return {
+            key: {
+                "name": record.name,
+                "occurrences": record.occurrences,
+                "interviews": record.interviews,
+                "offers": record.offers,
+                "notes": list(record.notes),
+            }
+            for key, record in self._skills.items()
+        }
+
+    @classmethod
+    def from_snapshot(cls, snapshot: Dict[str, Dict[str, object]]) -> "SkillsInventory":
+        inventory = cls()
+        for key, data in snapshot.items():
+            inventory._skills[key] = SkillRecord(
+                name=data.get("name", key),
+                occurrences=data.get("occurrences", 0),
+                interviews=data.get("interviews", 0),
+                offers=data.get("offers", 0),
+                notes=list(data.get("notes", [])),
+            )
+        return inventory
+
+    def sorted_by_opportunity(self) -> List[SkillRecord]:
+        """Return skills sorted by high demand but low success so far."""
+
+        return sorted(
+            self._skills.values(),
+            key=lambda record: (
+                -(record.occurrences - record.interviews - record.offers),
+                -record.occurrences,
+                record.name.lower(),
+            ),
+        )

--- a/src/jobofcron/storage.py
+++ b/src/jobofcron/storage.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
+from .application_queue import ApplicationQueue
 from .profile import CandidateProfile
 from .skills_inventory import SkillsInventory
 
@@ -15,21 +16,30 @@ class Storage:
     def __init__(self, path: Path) -> None:
         self.path = path
 
-    def load(self) -> tuple[CandidateProfile | None, SkillsInventory | None]:
+    def load(self) -> tuple[CandidateProfile | None, SkillsInventory | None, ApplicationQueue | None]:
         if not self.path.exists():
-            return None, None
+            return None, None, ApplicationQueue()
 
         data = json.loads(self.path.read_text(encoding="utf-8"))
         profile_data: Dict[str, Any] | None = data.get("profile")
         skills_data: Dict[str, Dict[str, Any]] | None = data.get("skills")
+        queue_data = data.get("queue", [])
 
         profile = CandidateProfile.from_dict(profile_data) if profile_data else None
         skills = SkillsInventory.from_snapshot(skills_data) if skills_data else None
-        return profile, skills
+        queue = ApplicationQueue.from_snapshot(queue_data) if queue_data is not None else ApplicationQueue()
+        return profile, skills, queue
 
-    def save(self, profile: CandidateProfile, skills: SkillsInventory) -> None:
+    def save(
+        self,
+        profile: CandidateProfile,
+        skills: SkillsInventory,
+        queue: ApplicationQueue | None = None,
+    ) -> None:
+        queue = queue or ApplicationQueue()
         payload = {
             "profile": profile.to_dict(),
             "skills": skills.to_snapshot(),
+            "queue": queue.to_snapshot(),
         }
         self.path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/src/jobofcron/storage.py
+++ b/src/jobofcron/storage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .application_queue import ApplicationQueue
+from .job_history import AppliedJobRegistry
 from .profile import CandidateProfile
 from .skills_inventory import SkillsInventory
 
@@ -16,30 +17,42 @@ class Storage:
     def __init__(self, path: Path) -> None:
         self.path = path
 
-    def load(self) -> tuple[CandidateProfile | None, SkillsInventory | None, ApplicationQueue | None]:
+    def load(
+        self,
+    ) -> tuple[
+        CandidateProfile | None,
+        SkillsInventory | None,
+        ApplicationQueue | None,
+        AppliedJobRegistry | None,
+    ]:
         if not self.path.exists():
-            return None, None, ApplicationQueue()
+            return None, None, ApplicationQueue(), AppliedJobRegistry()
 
         data = json.loads(self.path.read_text(encoding="utf-8"))
         profile_data: Dict[str, Any] | None = data.get("profile")
         skills_data: Dict[str, Dict[str, Any]] | None = data.get("skills")
         queue_data = data.get("queue", [])
+        history_data = data.get("history")
 
         profile = CandidateProfile.from_dict(profile_data) if profile_data else None
         skills = SkillsInventory.from_snapshot(skills_data) if skills_data else None
         queue = ApplicationQueue.from_snapshot(queue_data) if queue_data is not None else ApplicationQueue()
-        return profile, skills, queue
+        history = AppliedJobRegistry.from_snapshot(history_data)
+        return profile, skills, queue, history
 
     def save(
         self,
         profile: CandidateProfile,
         skills: SkillsInventory,
         queue: ApplicationQueue | None = None,
+        history: AppliedJobRegistry | None = None,
     ) -> None:
         queue = queue or ApplicationQueue()
+        history = history or AppliedJobRegistry()
         payload = {
             "profile": profile.to_dict(),
             "skills": skills.to_snapshot(),
             "queue": queue.to_snapshot(),
+            "history": history.to_snapshot(),
         }
         self.path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/src/jobofcron/storage.py
+++ b/src/jobofcron/storage.py
@@ -1,0 +1,35 @@
+"""Simple JSON-based persistence for the job application assistant."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .profile import CandidateProfile
+from .skills_inventory import SkillsInventory
+
+
+class Storage:
+    """Persist profile and skills inventory to a JSON file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def load(self) -> tuple[CandidateProfile | None, SkillsInventory | None]:
+        if not self.path.exists():
+            return None, None
+
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        profile_data: Dict[str, Any] | None = data.get("profile")
+        skills_data: Dict[str, Dict[str, Any]] | None = data.get("skills")
+
+        profile = CandidateProfile.from_dict(profile_data) if profile_data else None
+        skills = SkillsInventory.from_snapshot(skills_data) if skills_data else None
+        return profile, skills
+
+    def save(self, profile: CandidateProfile, skills: SkillsInventory) -> None:
+        payload = {
+            "profile": profile.to_dict(),
+            "skills": skills.to_snapshot(),
+        }
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/src/jobofcron/streamlit_app.py
+++ b/src/jobofcron/streamlit_app.py
@@ -1,0 +1,525 @@
+"""Streamlit interface for the Jobofcron automation toolkit.
+
+The UI focuses on helping users manage their profile, discover roles via the
+Google search helper, analyse job descriptions, review skill trends, and plan
+their application queue. The goal is to provide a human-in-the-loop cockpit
+that sits on top of the existing CLI building blocks.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import streamlit as st
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+
+if __package__ in {None, ""}:
+    sys.path.append(str(PACKAGE_DIR.parent))
+    from jobofcron.application_queue import ApplicationQueue, QueuedApplication  # type: ignore[attr-defined]
+    from jobofcron.job_matching import JobPosting, analyse_job_fit  # type: ignore[attr-defined]
+    from jobofcron.job_search import GoogleJobSearch, SearchResult  # type: ignore[attr-defined]
+    from jobofcron.profile import CandidateProfile  # type: ignore[attr-defined]
+    from jobofcron.skills_inventory import SkillsInventory  # type: ignore[attr-defined]
+    from jobofcron.storage import Storage  # type: ignore[attr-defined]
+else:
+    from .application_queue import ApplicationQueue, QueuedApplication
+    from .job_matching import JobPosting, analyse_job_fit
+    from .job_search import GoogleJobSearch, SearchResult
+    from .profile import CandidateProfile
+    from .skills_inventory import SkillsInventory
+    from .storage import Storage
+
+DEFAULT_STORAGE = Path(os.getenv("JOBOFCRON_STORAGE", "jobofcron_data.json"))
+
+
+def _load_state(path: Path) -> tuple[CandidateProfile, SkillsInventory, ApplicationQueue, Storage]:
+    storage = Storage(path)
+    profile, inventory, queue = storage.load()
+
+    if profile is None:
+        profile = CandidateProfile(name="Unknown", email="unknown@example.com")
+    if inventory is None:
+        inventory = SkillsInventory()
+    if queue is None:
+        queue = ApplicationQueue()
+
+    return profile, inventory, queue, storage
+
+
+def _initialise_session_state() -> None:
+    if "storage_path" not in st.session_state:
+        st.session_state.storage_path = str(DEFAULT_STORAGE)
+    if "loaded_storage_path" not in st.session_state:
+        profile, inventory, queue, storage = _load_state(Path(st.session_state.storage_path))
+        st.session_state.profile = profile
+        st.session_state.inventory = inventory
+        st.session_state.queue = queue
+        st.session_state.storage = storage
+        st.session_state.loaded_storage_path = st.session_state.storage_path
+    if "search_results" not in st.session_state:
+        st.session_state.search_results = []
+
+
+def _reload_state_if_needed(path_text: str) -> None:
+    if path_text != st.session_state.get("loaded_storage_path"):
+        profile, inventory, queue, storage = _load_state(Path(path_text))
+        st.session_state.profile = profile
+        st.session_state.inventory = inventory
+        st.session_state.queue = queue
+        st.session_state.storage = storage
+        st.session_state.loaded_storage_path = path_text
+
+
+def _save_state() -> None:
+    storage: Storage = st.session_state.storage
+    storage.save(st.session_state.profile, st.session_state.inventory, st.session_state.queue)
+
+
+def _export_results_to_csv(results: Iterable[SearchResult]) -> bytes:
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(["title", "link", "snippet", "source", "is_company_site"])
+    for result in results:
+        writer.writerow([result.title, result.link, result.snippet, result.source, "yes" if result.is_company_site else "no"])
+    return buffer.getvalue().encode("utf-8")
+
+
+def _render_profile_tab() -> None:
+    profile: CandidateProfile = st.session_state.profile
+
+    st.subheader("Contact & Preferences")
+    with st.form("profile_form", clear_on_submit=False):
+        name = st.text_input("Name", value=profile.name)
+        email = st.text_input("Email", value=profile.email)
+        phone = st.text_input("Phone", value=profile.phone or "")
+        summary = st.text_area("Professional summary", value=profile.summary or "", height=120)
+
+        prefs = profile.job_preferences
+        min_salary = st.text_input(
+            "Minimum salary (USD)",
+            value=str(prefs.min_salary or ""),
+            help="Leave blank if you are flexible. Use annual salary in USD.",
+        )
+        locations_text = st.text_area(
+            "Preferred locations",
+            value="\n".join(prefs.locations),
+            help="Enter one location per line. Include 'Remote' if applicable.",
+        )
+        domains_text = st.text_area(
+            "Focus domains",
+            value="\n".join(prefs.focus_domains),
+            help="Industries or domains to prioritise during searches.",
+        )
+        felon_friendly = st.checkbox(
+            "Require felon friendly roles",
+            value=prefs.felon_friendly_only,
+            help="When enabled, highlight postings that explicitly welcome justice-involved candidates.",
+        )
+
+        submitted = st.form_submit_button("Save profile")
+        if submitted:
+            profile.name = name.strip() or "Unknown"
+            profile.email = email.strip() or "unknown@example.com"
+            profile.phone = phone.strip() or None
+            profile.summary = summary.strip() or None
+
+            if min_salary.strip():
+                try:
+                    prefs.min_salary = int(min_salary.replace(",", "").strip())
+                except ValueError:
+                    st.error("Minimum salary must be a whole number.")
+                    return
+            else:
+                prefs.min_salary = None
+
+            prefs.locations = [loc.strip() for loc in locations_text.splitlines() if loc.strip()]
+            prefs.focus_domains = [domain.strip() for domain in domains_text.splitlines() if domain.strip()]
+            prefs.felon_friendly_only = felon_friendly
+
+            st.session_state.profile = profile
+            _save_state()
+            st.success("Profile updated.")
+
+    st.markdown("---")
+    st.subheader("Skills")
+    skill_input = st.text_input("Add a skill", key="add_skill_input")
+    if st.button("Add skill", key="add_skill_button"):
+        if skill_input.strip():
+            profile.add_skill(skill_input.strip())
+            st.session_state.inventory.observe_skills([skill_input.strip()])
+            _save_state()
+            st.success(f"Added skill '{skill_input.strip()}'.")
+            st.session_state["add_skill_input"] = ""
+        else:
+            st.warning("Enter a skill name before adding.")
+
+    if profile.skills:
+        st.write(sorted(profile.skills))
+    else:
+        st.info("No skills recorded yet. Use the field above to add them.")
+
+
+def _run_search(
+    title: str,
+    location: str,
+    limit: int,
+    remote: bool,
+    direct_only: bool,
+    extra_terms: Iterable[str],
+    serpapi_key: str,
+    sample_payload: Optional[dict],
+) -> List[SearchResult]:
+    if sample_payload is not None:
+        results = GoogleJobSearch.parse_results(sample_payload)
+    else:
+        searcher = GoogleJobSearch(serpapi_key)
+        results = searcher.search_jobs(
+            title=title,
+            location=location,
+            max_results=limit,
+            remote=remote,
+            extra_terms=[term for term in extra_terms if term],
+        )
+
+    if direct_only:
+        results = GoogleJobSearch.filter_direct_apply(results)
+    return results[:limit]
+
+
+def _render_search_tab() -> None:
+    profile: CandidateProfile = st.session_state.profile
+
+    with st.form("search_form"):
+        title = st.text_input("Job title or keywords", value="")
+        location = st.text_input(
+            "Location",
+            value=profile.job_preferences.locations[0] if profile.job_preferences.locations else "",
+        )
+        limit = st.slider("Result limit", min_value=1, max_value=20, value=10)
+        remote = st.checkbox("Prefer remote roles", value="Remote" in profile.job_preferences.locations)
+        direct_only = st.checkbox("Company sites only", value=True)
+        extra_terms_text = st.text_input(
+            "Extra search terms",
+            value=" ".join(profile.job_preferences.focus_domains),
+            help="Optional additional keywords (e.g. industry, company).",
+        )
+        serpapi_key = st.text_input(
+            "SerpAPI key",
+            value=os.getenv("SERPAPI_KEY", ""),
+            type="password",
+            help="Provide an API key for live Google searches or upload a saved response below.",
+        )
+        sample_response = st.file_uploader("Sample SerpAPI response (JSON)", type="json")
+
+        submitted = st.form_submit_button("Search")
+
+    if submitted:
+        if not title.strip():
+            st.error("Enter a job title or keyword to search.")
+            return
+        if not location.strip() and not remote:
+            st.warning("Provide a location or enable remote roles for best results.")
+
+        payload: Optional[dict] = None
+        if sample_response is not None:
+            try:
+                payload = json.load(sample_response)
+            except json.JSONDecodeError as exc:  # pragma: no cover - user input
+                st.error(f"Could not parse uploaded JSON: {exc}")
+                return
+        elif not serpapi_key.strip():
+            st.error("Provide either a SerpAPI key or a sample response.")
+            return
+
+        try:
+            results = _run_search(
+                title=title.strip(),
+                location=location.strip(),
+                limit=limit,
+                remote=remote,
+                direct_only=direct_only,
+                extra_terms=extra_terms_text.split(),
+                serpapi_key=serpapi_key.strip(),
+                sample_payload=payload,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            st.error(f"Search failed: {exc}")
+            return
+
+        st.session_state.search_results = results
+        if results:
+            st.success(f"Found {len(results)} results.")
+        else:
+            st.info("No results matched the filters. Try broadening your query.")
+
+    results = st.session_state.get("search_results", [])
+    if results:
+        table_data = [
+            {
+                "Title": result.title,
+                "Source": result.source,
+                "Company site?": "Yes" if result.is_company_site else "No",
+                "Link": result.link,
+                "Snippet": result.snippet,
+            }
+            for result in results
+        ]
+        st.dataframe(table_data, use_container_width=True, hide_index=True)
+
+        csv_bytes = _export_results_to_csv(results)
+        st.download_button(
+            "Export results to CSV",
+            data=csv_bytes,
+            file_name="jobofcron_search_results.csv",
+            mime="text/csv",
+        )
+    else:
+        st.info("Run a search to see direct-apply opportunities.")
+
+
+def _render_analysis_tab() -> None:
+    profile: CandidateProfile = st.session_state.profile
+    inventory: SkillsInventory = st.session_state.inventory
+
+    results = st.session_state.get("search_results", [])
+    default_title = results[0].title if results else ""
+    options = ["Manual entry"] + [f"{res.title} ({res.source})" for res in results]
+    choice = st.selectbox("Select a job to analyse", options)
+
+    selected: Optional[SearchResult] = None
+    if choice != "Manual entry":
+        selected = results[options.index(choice) - 1]
+
+    with st.form("analysis_form"):
+        title = st.text_input("Job title", value=selected.title if selected else default_title)
+        company = st.text_input("Company", value="")
+        location = st.text_input("Location", value="")
+        salary_text = st.text_input("Salary info", value="")
+        apply_url = st.text_input("Apply URL", value=selected.link if selected else "")
+        description = st.text_area(
+            "Job description",
+            value=selected.snippet if selected else "",
+            height=220,
+            help="Paste the full job description for the best assessment.",
+        )
+        tags_text = st.text_input("Tags", value="")
+        felon_friendly = st.selectbox(
+            "Felon friendly?",
+            options=["Unknown", "Yes", "No"],
+            index=0,
+            help="Use when the posting explicitly mentions justice-involved candidates.",
+        )
+        submitted = st.form_submit_button("Analyse job match")
+
+    if submitted:
+        if not title.strip() or not company.strip():
+            st.error("Provide both a job title and company name.")
+            return
+        posting = JobPosting(
+            title=title.strip(),
+            company=company.strip(),
+            location=location.strip() or None,
+            salary_text=salary_text.strip() or None,
+            description=description,
+            tags=[tag.strip() for tag in tags_text.split(",") if tag.strip()],
+            felon_friendly=None
+            if felon_friendly == "Unknown"
+            else felon_friendly == "Yes",
+            apply_url=apply_url.strip() or (selected.link if selected else None),
+        )
+        assessment = analyse_job_fit(profile, posting)
+        inventory.observe_skills(assessment.required_skills)
+        _save_state()
+
+        score_pct = int(round(assessment.match_score * 100))
+        st.success(f"Match score: {score_pct}%")
+        st.progress(assessment.match_score)
+
+        cols = st.columns(2)
+        cols[0].metric("Skills matched", len(assessment.matched_skills))
+        cols[1].metric("Skills missing", len(assessment.missing_skills))
+
+        if assessment.required_skills:
+            st.markdown("### Required skills")
+            st.write(
+                {
+                    "Matched": assessment.matched_skills,
+                    "Missing": assessment.missing_skills,
+                }
+            )
+
+        if assessment.recommended_questions:
+            st.markdown("### Follow-up questions")
+            for question in assessment.recommended_questions:
+                st.write(f"- {question}")
+
+        if assessment.recommended_profile_updates:
+            st.markdown("### Resume & cover letter focus")
+            for update in assessment.recommended_profile_updates:
+                st.write(f"- {update}")
+
+        if assessment.salary_notes:
+            st.markdown("### Salary notes")
+            for note in assessment.salary_notes:
+                st.write(f"- {note}")
+        elif assessment.meets_salary is True:
+            st.info("Posting appears to meet your minimum salary preference.")
+
+        if assessment.location_notes:
+            st.markdown("### Location notes")
+            for note in assessment.location_notes:
+                st.write(f"- {note}")
+        elif assessment.meets_location is True:
+            st.info("Posting aligns with your saved location preferences.")
+
+        if assessment.felon_friendly is True:
+            st.success("Posting explicitly welcomes justice-involved candidates.")
+        elif assessment.felon_friendly is False:
+            st.warning("Posting may require a clean record; investigate further before applying.")
+        else:
+            st.info("No clear felon-friendly signals detected.")
+
+        with st.expander("Add to application queue"):
+            schedule_time = st.datetime_input(
+                "Schedule application for",
+                value=datetime.now(),
+                key="queue_schedule_time",
+            )
+            resume_path = st.text_input("Resume path", value="", key="queue_resume_path")
+            cover_path = st.text_input("Cover letter path", value="", key="queue_cover_path")
+            if st.button("Queue application", key="queue_submit_button"):
+                queued = QueuedApplication(
+                    posting=posting,
+                    apply_at=schedule_time,
+                    resume_path=resume_path or None,
+                    cover_letter_path=cover_path or None,
+                )
+                st.session_state.queue.add(queued)
+                _save_state()
+                st.success(f"Queued {queued.job_id} for {schedule_time.isoformat(timespec='minutes')}.")
+
+
+def _render_skills_tab() -> None:
+    inventory: SkillsInventory = st.session_state.inventory
+
+    records = inventory.sorted_by_opportunity()
+    if not records:
+        st.info("No skill observations yet. Analyse job descriptions to populate this dashboard.")
+        return
+
+    table = [
+        {
+            "Skill": record.name,
+            "Demand": record.occurrences,
+            "Interviews": record.interviews,
+            "Offers": record.offers,
+            "Notes": " | ".join(record.notes),
+        }
+        for record in records
+    ]
+    st.dataframe(table, hide_index=True, use_container_width=True)
+
+    with st.form("skill_notes_form"):
+        skill_names = [record.name for record in records]
+        selection = st.selectbox("Select a skill", skill_names)
+        interviews = st.number_input("Interviews", min_value=0, value=0, step=1)
+        offers = st.number_input("Offers", min_value=0, value=0, step=1)
+        note = st.text_input("Add note", value="")
+        submitted = st.form_submit_button("Update skill")
+
+    if submitted:
+        record = inventory.ensure(selection)
+        for _ in range(interviews):
+            record.record_interview()
+        for _ in range(offers):
+            record.record_offer()
+        if note.strip():
+            record.add_note(note)
+        _save_state()
+        st.success(f"Updated skill '{selection}'.")
+
+
+def _render_queue_tab() -> None:
+    queue: ApplicationQueue = st.session_state.queue
+
+    pending = queue.items
+    if not pending:
+        st.info("No applications scheduled. Use the analysis tab to add new ones.")
+        return
+
+    for idx, application in enumerate(list(pending)):
+        header = f"{application.posting.title} @ {application.posting.company}"
+        with st.expander(header, expanded=False):
+            st.write(f"Scheduled for: {application.apply_at.isoformat(timespec='minutes')}")
+            st.write(f"Status: {application.status}")
+            if application.resume_path:
+                st.write(f"Resume: {application.resume_path}")
+            if application.cover_letter_path:
+                st.write(f"Cover letter: {application.cover_letter_path}")
+            if application.notes:
+                st.markdown("### Notes")
+                for note in application.notes:
+                    st.write(f"- {note}")
+            if application.last_error:
+                st.error(f"Last error: {application.last_error}")
+
+            col1, col2, col3 = st.columns(3)
+            if col1.button("Mark applied", key=f"queue_apply_{idx}"):
+                application.mark_success()
+                _save_state()
+                st.experimental_rerun()
+            if col2.button("Reschedule", key=f"queue_reschedule_{idx}"):
+                new_time = datetime.now().replace(second=0, microsecond=0)
+                application.defer(new_time)
+                _save_state()
+                st.success(f"Rescheduled for {new_time.isoformat(timespec='minutes')}.")
+            if col3.button("Remove", key=f"queue_remove_{idx}"):
+                queue.items.pop(idx)
+                _save_state()
+                st.experimental_rerun()
+
+
+def main() -> None:
+    st.set_page_config(page_title="Jobofcron Control Centre", layout="wide")
+    _initialise_session_state()
+
+    st.sidebar.title("Settings")
+    storage_path = st.sidebar.text_input("Storage file", value=st.session_state.storage_path)
+    if storage_path != st.session_state.storage_path:
+        st.session_state.storage_path = storage_path
+    _reload_state_if_needed(storage_path)
+
+    st.title("Jobofcron Control Centre")
+    st.caption("Plan direct applications, tailor documents, and track job hunt progress.")
+
+    tabs = st.tabs(
+        [
+            "Profile",
+            "Job search",
+            "Job analysis",
+            "Skills dashboard",
+            "Application queue",
+        ]
+    )
+
+    with tabs[0]:
+        _render_profile_tab()
+    with tabs[1]:
+        _render_search_tab()
+    with tabs[2]:
+        _render_analysis_tab()
+    with tabs[3]:
+        _render_skills_tab()
+    with tabs[4]:
+        _render_queue_tab()
+
+
+if __name__ == "__main__":  # pragma: no cover - Streamlit entry point
+    main()

--- a/src/jobofcron/worker.py
+++ b/src/jobofcron/worker.py
@@ -1,0 +1,125 @@
+"""Background worker for orchestrating scheduled applications."""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .application_automation import AutomationDependencyError, DirectApplyAutomation
+from .application_queue import ApplicationQueue, QueuedApplication
+from .document_generation import generate_cover_letter, generate_resume
+from .job_matching import MatchAssessment, analyse_job_fit
+from .profile import CandidateProfile
+from .skills_inventory import SkillsInventory
+from .storage import Storage
+
+
+def _slugify(*parts: str) -> str:
+    cleaned = "-".join(part.strip().lower().replace(" ", "-") for part in parts if part)
+    return "".join(char for char in cleaned if char.isalnum() or char in {"-", "_"})
+
+
+class JobAutomationWorker:
+    """Run pending applications from the queue using the automation helpers."""
+
+    def __init__(
+        self,
+        storage_path: Path,
+        *,
+        documents_dir: Optional[Path] = None,
+        headless: bool = True,
+        timeout: int = 90,
+        retry_delay: timedelta = timedelta(minutes=45),
+    ) -> None:
+        self.storage = Storage(storage_path)
+        self.documents_dir = documents_dir or Path("generated_documents")
+        self.documents_dir.mkdir(parents=True, exist_ok=True)
+        self.retry_delay = retry_delay
+        self.automation = DirectApplyAutomation(headless=headless, timeout=timeout)
+
+    def run_once(self, *, dry_run: bool = False) -> None:
+        profile, inventory, queue = self._load_state()
+        now = datetime.now()
+        due = queue.due(now)
+
+        if not due:
+            print("No pending applications ready to run.")
+            return
+
+        for task in due:
+            print(f"Processing {task.posting.title} at {task.posting.company} (job id: {task.job_id})")
+            assessment = analyse_job_fit(profile, task.posting)
+            inventory.observe_skills(assessment.required_skills)
+
+            resume_path, cover_path = self._ensure_documents(task, profile, assessment)
+
+            try:
+                if dry_run:
+                    print(f"[dry-run] Would submit application to {task.posting.apply_url}")
+                    task.notes.append("Dry run executed; application remains queued for a real run.")
+                    task.defer(now + self.retry_delay)
+                    continue
+                else:
+                    submitted = self.automation.apply(
+                        profile,
+                        task.posting,
+                        resume_path=resume_path,
+                        cover_letter_path=cover_path,
+                    )
+                    if submitted:
+                        task.mark_success()
+                    else:
+                        task.mark_failure("No submit button detected")
+                        task.defer(now + self.retry_delay)
+                        print("Submit control not detected; task re-queued.")
+                        continue
+            except AutomationDependencyError as exc:
+                task.mark_failure(str(exc))
+                task.defer(now + self.retry_delay)
+                print(f"Automation dependency missing: {exc}")
+            except Exception as exc:  # pragma: no cover - integration heavy
+                task.mark_failure(str(exc))
+                task.defer(now + self.retry_delay)
+                print(f"Automation failed: {exc}")
+
+        self.storage.save(profile, inventory, queue)
+
+    def run_forever(self, *, interval: int = 300, dry_run: bool = False) -> None:
+        while True:
+            self.run_once(dry_run=dry_run)
+            time.sleep(interval)
+
+    def _ensure_documents(
+        self,
+        task: QueuedApplication,
+        profile,
+        assessment: MatchAssessment,
+    ) -> tuple[Path, Path]:
+        slug = _slugify(task.posting.title, task.posting.company, task.job_id)
+        resume_path = Path(task.resume_path) if task.resume_path else self.documents_dir / f"{slug}_resume.md"
+        cover_path = (
+            Path(task.cover_letter_path)
+            if task.cover_letter_path
+            else self.documents_dir / f"{slug}_cover_letter.md"
+        )
+
+        resume_text = generate_resume(profile, task.posting, assessment)
+        resume_path.write_text(resume_text, encoding="utf-8")
+        task.resume_path = str(resume_path)
+
+        cover_letter = generate_cover_letter(profile, task.posting, assessment)
+        cover_path.write_text(cover_letter, encoding="utf-8")
+        task.cover_letter_path = str(cover_path)
+
+        return resume_path, cover_path
+
+    def _load_state(self) -> tuple:
+        profile, inventory, queue = self.storage.load()
+        if profile is None:
+            profile = CandidateProfile(name="Unknown", email="unknown@example.com")
+        if inventory is None:
+            inventory = SkillsInventory()
+        if queue is None:
+            queue = ApplicationQueue()
+        return profile, inventory, queue


### PR DESCRIPTION
## Summary
- add a Python package scaffold with profile, skills inventory, scheduler, and persistence helpers
- provide a CLI to inspect/update preferences, add skills, and plan application pacing
- document local usage instructions and editable installation steps in the README

## Testing
- python -m jobofcron.cli show

------
https://chatgpt.com/codex/tasks/task_e_68e5a9eb30808326955169592e3bd247